### PR TITLE
Fix Dependabot: valibot flatten() inherited property paths (GHSA-5qjj-4xww-7phc)

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,8 @@
       "sharp": "^0.35.3",
       "fast-uri": "^3.1.4",
       "@hono/node-server": "2.0.11",
-      "postcss": ">=8.5.18"
+      "postcss": ">=8.5.18",
+      "valibot": ">=1.4.2"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   fast-uri: ^3.1.4
   '@hono/node-server': 2.0.11
   postcss: '>=8.5.18'
+  valibot: '>=1.4.2'
 
 importers:
 
@@ -5447,8 +5448,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  valibot@1.2.0:
-    resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -6666,7 +6667,7 @@ snapshots:
       proper-lockfile: 4.1.2
       remeda: 2.33.4
       std-env: 3.10.0
-      valibot: 1.2.0(typescript@5.9.3)
+      valibot: 1.4.2(typescript@5.9.3)
       zeptomatch: 2.1.0
     transitivePeerDependencies:
       - typescript
@@ -11571,7 +11572,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  valibot@1.2.0(typescript@5.9.3):
+  valibot@1.4.2(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
 


### PR DESCRIPTION
## Summary
- Resolves [Dependabot alert #26](https://github.com/Peon-sh/Peon/security/dependabot/26) ([GHSA-5qjj-4xww-7phc](https://github.com/advisories/GHSA-5qjj-4xww-7phc) / CVE-2026-59952)
- Adds a pnpm override for `valibot` → `>=1.4.2` (transitive via `@prisma/dev`)

## Test plan
- [ ] CI passes (install / audit / tests)
- [ ] Confirm lockfile resolves `valibot@1.4.2` (or newer)
- [ ] Dependabot alert #26 closes after merge


Made with [Cursor](https://cursor.com)