### PR TITLE
Backup instance dumps, queued restore, and rollback commit pin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 .DS_Store
 *.pem
 .data/
+/tmp/
 
 # debug
 npm-debug.log*

--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
       "fast-uri": "^3.1.4",
       "@hono/node-server": "2.0.11",
       "postcss": ">=8.5.18",
-      "valibot": ">=1.4.2"
+      "valibot": ">=1.4.2",
+      "brace-expansion": ">=5.0.8"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   '@hono/node-server': 2.0.11
   postcss: '>=8.5.18'
   valibot: '>=1.4.2'
+  brace-expansion: '>=5.0.8'
 
 importers:
 
@@ -2638,9 +2639,6 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -2673,12 +2671,9 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
-
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2821,9 +2816,6 @@ packages:
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   conf@10.2.0:
     resolution: {integrity: sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg==}
@@ -8247,8 +8239,6 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -8285,12 +8275,7 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@1.1.15:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -8434,8 +8419,6 @@ snapshots:
   commander@11.1.0: {}
 
   commander@14.0.3: {}
-
-  concat-map@0.0.1: {}
 
   conf@10.2.0:
     dependencies:
@@ -10202,11 +10185,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.15
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 

--- a/prisma/migrations/20260724183000_backup_dump_all_default/migration.sql
+++ b/prisma/migrations/20260724183000_backup_dump_all_default/migration.sql
@@ -1,0 +1,6 @@
+-- Instance-wide dumps are the default for new schedules; flip existing rows too
+-- since dumpAll was previously unused (always single-DB dump).
+ALTER TABLE "ScheduledBackup" ALTER COLUMN "dumpAll" SET DEFAULT true;
+UPDATE "ScheduledBackup" SET "dumpAll" = true;
+
+ALTER TABLE "ScheduledBackupExecution" ADD COLUMN IF NOT EXISTS "dumpAll" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -899,7 +899,8 @@ model ScheduledBackup {
   saveS3      Boolean @default(false)
   s3StorageId String?
   disableLocal Boolean @default(false)
-  dumpAll     Boolean @default(false)
+  /** When true, dump every database in the instance (pg_dumpall / --all-databases). */
+  dumpAll     Boolean @default(true)
   databasesToBackup String?
   timeout     Int     @default(3600)
   retentionAmountLocal Int @default(7)
@@ -925,6 +926,8 @@ model ScheduledBackupExecution {
   size      String?
   filename  String?
   databaseName String?
+  /** Mirrors the schedule's dumpAll at run time (for restore). */
+  dumpAll   Boolean         @default(true)
   s3Uploaded Boolean        @default(false)
   startedAt DateTime        @default(now())
   finishedAt DateTime?

--- a/src/app/(app)/projects/[projectId]/services/[serviceId]/page.tsx
+++ b/src/app/(app)/projects/[projectId]/services/[serviceId]/page.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { Suspense, use, useEffect, useRef, useState, type ReactNode } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient, useInfiniteQuery } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import {
   Trash2,
@@ -77,6 +77,7 @@ import {
   runBackupNow,
   listBackupExecutions,
   restoreBackup,
+  downloadBackup,
   type ServiceDetail,
   type ScheduledTaskItem,
   type ServiceConfigField,
@@ -98,6 +99,7 @@ import {
 import { PageContainer, Panel } from '@/components/app/page';
 import { ConfirmButton } from '@/components/app/confirm';
 import { StatusBadge } from '@/components/app/status-badge';
+import { RunOutput } from '@/components/app/run-output';
 import { KindChip } from '@/components/app/kind-chip';
 import { LocalDateTime } from '@/components/app/local-datetime';
 import { AccessGateBanner } from '@/components/billing/access-gate-banner';
@@ -2875,24 +2877,21 @@ function TaskExecutions({ serviceId, task }: { serviceId: string; task: Schedule
         {open ? ' ▲' : ' ▼'}
       </button>
       {open && (
-        <div className="mt-2 space-y-1.5">
+        <div className="mt-2 space-y-2">
           {executions?.length ? (
             executions.map((e) => (
-              <div key={e.id} className="bg-secondary/50 rounded-md px-3 py-2">
-                <div className="flex items-center justify-between">
-                  <span className={e.status === 'SUCCESS' ? 'text-phosphor' : e.status === 'FAILED' ? 'text-destructive' : ''}>
-                    {e.status.toLowerCase()}
-                  </span>
-                  <span className="text-muted-foreground">
+              <div
+                key={e.id}
+                className="border-border/60 bg-secondary/30 space-y-2 rounded-lg border px-3 py-2.5"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <StatusBadge status={e.status} />
+                  <span className="text-muted-foreground shrink-0 tabular-nums">
                     <LocalDateTime value={e.startedAt} />
                     {e.duration != null ? ` · ${(e.duration / 1000).toFixed(1)}s` : ''}
                   </span>
                 </div>
-                {e.message && (
-                  <pre className="text-muted-foreground mt-1 max-h-32 overflow-auto font-mono text-[10.5px] whitespace-pre-wrap">
-                    {e.message}
-                  </pre>
-                )}
+                <RunOutput message={e.message} />
               </div>
             ))
           ) : (
@@ -2918,10 +2917,11 @@ function BackupsTab({ serviceId }: { serviceId: string }) {
     enabled: !!workspaceId,
   });
   const [frequency, setFrequency] = useState('0 0 * * *');
+  const [dumpAll, setDumpAll] = useState(true);
   const invalidate = () => qc.invalidateQueries({ queryKey: ['backups', serviceId] });
 
   const addMut = useMutation({
-    mutationFn: () => createBackup(serviceId, { frequency }),
+    mutationFn: () => createBackup(serviceId, { frequency, dumpAll }),
     onSuccess: async () => {
       await invalidate();
       toast.success('Backup schedule created');
@@ -2951,7 +2951,21 @@ function BackupsTab({ serviceId }: { serviceId: string }) {
               onChange={(e) => setFrequency(e.target.value)}
             />
             <p className="text-muted-foreground text-[11px]">
-              A logical dump of the database is taken on this schedule and stored on the server (optionally uploaded to S3).
+              Logical dumps are stored on the server and can be downloaded or restored from previous runs.
+            </p>
+          </div>
+          <div className="space-y-1.5">
+            <Label>Backup scope</Label>
+            <div className="flex items-center gap-3 pt-1">
+              <Switch checked={dumpAll} onCheckedChange={setDumpAll} id="backup-dump-all" />
+              <Label htmlFor="backup-dump-all" className="font-normal text-[12.5px]">
+                Entire instance (all databases)
+              </Label>
+            </div>
+            <p className="text-muted-foreground text-[11px]">
+              {dumpAll
+                ? 'Uses pg_dumpall / --all-databases so every database in this service is included.'
+                : 'Dumps only the configured database name for this service.'}
             </p>
           </div>
         </div>
@@ -3024,6 +3038,7 @@ function BackupEditor({
   });
 
   const saveS3 = val('saveS3', false);
+  const dumpAll = val('dumpAll', true);
 
   return (
     <Panel
@@ -3031,6 +3046,11 @@ function BackupEditor({
         <span className="inline-flex items-center gap-2 font-mono">
           {backup.frequency}
           {!backup.enabled && <Badge variant="outline" className="text-[10px]">disabled</Badge>}
+          {backup.dumpAll ? (
+            <Badge variant="outline" className="text-[10px]">all dbs</Badge>
+          ) : (
+            <Badge variant="outline" className="text-[10px]">single db</Badge>
+          )}
           {backup.saveS3 && <Badge variant="outline" className="text-[10px]">S3</Badge>}
         </span>
       }
@@ -3058,7 +3078,7 @@ function BackupEditor({
         </>
       }
     >
-      <div className="grid gap-3 md:grid-cols-3">
+      <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-4">
         <div className="space-y-1.5">
           <Label>Frequency (cron)</Label>
           <Input
@@ -3074,6 +3094,15 @@ function BackupEditor({
             value={String(val('retentionAmountLocal', 7))}
             onChange={(e) => set('retentionAmountLocal', Number(e.target.value) || 0)}
           />
+        </div>
+        <div className="space-y-1.5">
+          <Label>Entire instance</Label>
+          <div className="flex items-center gap-3 pt-1">
+            <Switch checked={dumpAll} onCheckedChange={(c) => set('dumpAll', c)} />
+            <span className="text-muted-foreground text-[11px]">
+              {dumpAll ? 'all databases' : 'configured DB only'}
+            </span>
+          </div>
         </div>
         <div className="space-y-1.5">
           <Label>Upload to S3</Label>
@@ -3100,57 +3129,101 @@ function BackupEditor({
   );
 }
 
+function formatBackupSize(size: string | null): string | null {
+  if (!size) return null;
+  const n = Number(size);
+  if (!Number.isFinite(n) || n < 0) return null;
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
 function BackupExecutions({ serviceId, backup }: { serviceId: string; backup: ScheduledBackupItem }) {
-  const [open, setOpen] = useState(false);
-  const { data: executions } = useQuery({
+  const {
+    data,
+    isLoading,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+  } = useInfiniteQuery({
     queryKey: ['backup-executions', backup.id],
-    queryFn: () => listBackupExecutions(serviceId, backup.id),
-    enabled: open,
-    refetchInterval: open ? 5000 : false,
+    queryFn: ({ pageParam }) =>
+      listBackupExecutions(serviceId, backup.id, {
+        limit: 5,
+        cursor: pageParam,
+      }),
+    initialPageParam: null as string | null,
+    getNextPageParam: (last) => last.nextCursor,
+    refetchInterval: 5000,
   });
+
+  const items = data?.pages.flatMap((p) => p.items) ?? [];
 
   const restoreMut = useMutation({
     mutationFn: (filename: string) => restoreBackup(serviceId, filename),
-    onSuccess: () => toast.success('Restore completed'),
+    onSuccess: () => toast.success('Restore queued - the worker will apply it shortly'),
     onError: (e) => toast.error(e instanceof Error ? e.message : 'Restore failed'),
   });
 
+  const downloadMut = useMutation({
+    mutationFn: (filename: string) => downloadBackup(serviceId, filename),
+    onSuccess: () => toast.success('Download started'),
+    onError: (e) => toast.error(e instanceof Error ? e.message : 'Download failed'),
+  });
+
   return (
-    <div className="text-[11px]">
-      <button onClick={() => setOpen(!open)} className="text-muted-foreground hover:text-foreground transition-colors">
-        {backup._count.executions} execution{backup._count.executions === 1 ? '' : 's'}
-        {open ? ' ▲' : ' ▼'}
-      </button>
-      {open && (
-        <div className="mt-2 space-y-1.5">
-          {executions?.length ? (
-            executions.map((e) => (
+    <div className="space-y-2 text-[11px]">
+      <div className="text-muted-foreground font-medium tracking-wide uppercase">
+        Previous backups ({backup._count.executions})
+      </div>
+      <div className="space-y-1.5">
+        {isLoading && items.length === 0 ? (
+          <div className="text-muted-foreground">loading…</div>
+        ) : items.length ? (
+          <>
+            {items.map((e) => (
               <div key={e.id} className="bg-secondary/50 rounded-md px-3 py-2">
                 <div className="flex items-center justify-between gap-2">
                   <span className={e.status === 'SUCCESS' ? 'text-phosphor' : e.status === 'FAILED' ? 'text-destructive' : ''}>
                     {e.status.toLowerCase()}
+                    {e.dumpAll ? ' · all dbs' : e.databaseName ? ` · ${e.databaseName}` : ''}
                     {e.s3Uploaded ? ' · s3' : ''}
+                    {formatBackupSize(e.size) ? ` · ${formatBackupSize(e.size)}` : ''}
                   </span>
                   <span className="text-muted-foreground">
                     <LocalDateTime value={e.startedAt} />
                   </span>
                 </div>
                 {e.filename && (
-                  <div className="mt-1 flex items-center justify-between gap-2">
+                  <div className="mt-1 flex flex-wrap items-center justify-between gap-2">
                     <span className="text-muted-foreground truncate font-mono text-[10.5px]">{e.filename}</span>
                     {e.status === 'SUCCESS' && (
-                      <ConfirmButton
-                        onConfirm={() => restoreMut.mutate(e.filename!)}
-                        title="Restore this backup?"
-                        description="Existing data in the database will be replaced with the contents of this dump. This cannot be undone."
-                        confirmLabel="Restore"
-                        variant="outline"
-                        confirmVariant="default"
-                        size="sm"
-                        disabled={restoreMut.isPending}
-                      >
-                        Restore
-                      </ConfirmButton>
+                      <div className="flex items-center gap-1.5">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          disabled={downloadMut.isPending}
+                          onClick={() => downloadMut.mutate(e.filename!)}
+                        >
+                          <Download className="size-3.5" /> Download
+                        </Button>
+                        <ConfirmButton
+                          onConfirm={() => restoreMut.mutate(e.filename!)}
+                          title="Queue restore of this backup?"
+                          description={
+                            e.dumpAll
+                              ? 'The restore will be queued and applied by the worker. All databases in this instance may be overwritten. This cannot be undone.'
+                              : 'The restore will be queued and applied by the worker. Existing data in the database may be overwritten. This cannot be undone.'
+                          }
+                          confirmLabel="Queue restore"
+                          variant="outline"
+                          confirmVariant="default"
+                          size="sm"
+                          disabled={restoreMut.isPending}
+                        >
+                          Restore
+                        </ConfirmButton>
+                      </div>
                     )}
                   </div>
                 )}
@@ -3160,12 +3233,23 @@ function BackupExecutions({ serviceId, backup }: { serviceId: string; backup: Sc
                   </pre>
                 )}
               </div>
-            ))
-          ) : (
-            <div className="text-muted-foreground">no executions yet.</div>
-          )}
-        </div>
-      )}
+            ))}
+            {hasNextPage ? (
+              <Button
+                size="sm"
+                variant="outline"
+                className="w-full"
+                disabled={isFetchingNextPage}
+                onClick={() => void fetchNextPage()}
+              >
+                {isFetchingNextPage ? 'Loading…' : 'Load more'}
+              </Button>
+            ) : null}
+          </>
+        ) : (
+          <div className="text-muted-foreground">no previous backups yet. run “Backup now” to create one.</div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/app/(app)/servers/page.tsx
+++ b/src/app/(app)/servers/page.tsx
@@ -4,11 +4,17 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { Plus, Server, ArrowRight } from 'lucide-react';
+import { Plus, Server, ArrowRight, Copy, Check, KeyRound, CircleHelp } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { SearchableSelect } from '@/components/ui/searchable-select';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import {
   Modal,
   ModalBody,
@@ -23,7 +29,7 @@ import { EmptyState } from '@/components/app/empty-state';
 import { StatusBadge } from '@/components/app/status-badge';
 import { useAuthStore } from '@/store/auth';
 import { listServers, createServer, type ProxyType } from '@/services/api/server';
-import { listPrivateKeys } from '@/services/api/privatekey';
+import { listPrivateKeys, createPrivateKey } from '@/services/api/privatekey';
 
 export default function ServersPage() {
   const { currentWorkspaceId } = useAuthStore();
@@ -37,6 +43,10 @@ export default function ServersPage() {
   const [user, setUser] = useState('root');
   const [privateKeyId, setPrivateKeyId] = useState('');
   const [proxyType, setProxyType] = useState<ProxyType>('TRAEFIK');
+  const [showNewKey, setShowNewKey] = useState(false);
+  const [newKeyName, setNewKeyName] = useState('');
+  const [createdPublicKey, setCreatedPublicKey] = useState<string | null>(null);
+  const [copiedPub, setCopiedPub] = useState(false);
 
   const { data: servers, isLoading } = useQuery({
     queryKey: ['servers', wsId],
@@ -57,6 +67,10 @@ export default function ServersPage() {
     setUser('root');
     setPrivateKeyId('');
     setProxyType('TRAEFIK');
+    setShowNewKey(false);
+    setNewKeyName('');
+    setCreatedPublicKey(null);
+    setCopiedPub(false);
   };
 
   const createMut = useMutation({
@@ -78,16 +92,44 @@ export default function ServersPage() {
     onError: (e) => toast.error(e instanceof Error ? e.message : 'Failed'),
   });
 
+  const createKeyMut = useMutation({
+    mutationFn: () =>
+      createPrivateKey(wsId, {
+        name: newKeyName.trim() || `${name.trim() || 'server'}-ssh`,
+        generate: true,
+      }),
+    onSuccess: async (key) => {
+      await qc.invalidateQueries({ queryKey: ['private-keys', wsId] });
+      setPrivateKeyId(key.id);
+      setCreatedPublicKey(key.publicKey ?? null);
+      setShowNewKey(false);
+      setNewKeyName('');
+      toast.success('SSH key generated — add the public key to the server before connecting');
+    },
+    onError: (e) => toast.error(e instanceof Error ? e.message : 'Failed to create SSH key'),
+  });
+
+  const copyPublicKey = async () => {
+    if (!createdPublicKey) return;
+    try {
+      await navigator.clipboard.writeText(createdPublicKey);
+      setCopiedPub(true);
+      toast.success('Public key copied');
+      window.setTimeout(() => setCopiedPub(false), 2000);
+    } catch {
+      toast.error('Could not copy public key');
+    }
+  };
+
   const createDialog = (
     <Modal open={open} onOpenChange={(o) => { setOpen(o); if (!o) reset(); }}>
-      <ModalContent>
+      <ModalContent size="lg">
         <ModalHeader>
           <ModalTitle>Add server</ModalTitle>
         </ModalHeader>
         <ModalBody>
           <ModalDescription className="mb-4">
-            Connect a Linux host over SSH. After you add it, open the server and click Connect to
-            verify SSH and install the monitoring agent.
+            Connect a Linux host over SSH to deploy and manage services.
           </ModalDescription>
           <div className="space-y-4">
               <div className="space-y-2">
@@ -117,29 +159,157 @@ export default function ServersPage() {
                 <Input id="s-user" value={user} onChange={(e) => setUser(e.target.value)} />
               </div>
               <div className="space-y-2">
-                <Label>Private key</Label>
-                <SearchableSelect
-                  value={privateKeyId}
-                  onValueChange={setPrivateKeyId}
-                  placeholder="Select private key"
-                  options={(keys ?? []).map((k) => ({ value: k.id, label: k.name }))}
-                />
-                {!keys?.length && (
-                  <p className="text-muted-foreground text-xs">
-                    No private keys yet.{' '}
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="flex min-w-0 items-center gap-1.5">
+                    <Label>SSH key</Label>
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            className="text-muted-foreground hover:text-foreground shrink-0"
+                            aria-label="About SSH key"
+                          >
+                            <CircleHelp className="size-3.5" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent side="top" className="max-w-xs text-left leading-relaxed">
+                          Connect a Linux host over SSH. Peon needs an SSH key whose public half is
+                          in the host&apos;s ~/.ssh/authorized_keys. After you add the server, open
+                          it and click Connect to verify SSH and install the monitoring agent.
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  </div>
+                  <Link
+                    href="/keys-and-tokens"
+                    className="text-phosphor text-[11px] underline-offset-2 hover:underline"
+                    onClick={() => setOpen(false)}
+                  >
+                    Keys &amp; Tokens → SSH Keys
+                  </Link>
+                </div>
+                {(keys?.length ?? 0) > 0 ? (
+                  <SearchableSelect
+                    value={privateKeyId}
+                    onValueChange={(id) => {
+                      setPrivateKeyId(id);
+                      setCreatedPublicKey(keys?.find((k) => k.id === id)?.publicKey ?? null);
+                    }}
+                    placeholder="Select SSH key"
+                    options={(keys ?? []).map((k) => ({ value: k.id, label: k.name }))}
+                  />
+                ) : (
+                  <p className="text-muted-foreground border-border/60 rounded-md border border-dashed px-3 py-2 text-xs">
+                    No SSH keys in this workspace yet. Generate one below, or create one under{' '}
                     <Link
                       href="/keys-and-tokens"
                       className="text-phosphor underline-offset-2 hover:underline"
                       onClick={() => setOpen(false)}
                     >
-                      Create one under Keys & Tokens → Private keys
+                      Keys &amp; Tokens
                     </Link>
                     .
                   </p>
                 )}
+
+                {!showNewKey ? (
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    className="w-full sm:w-auto"
+                    onClick={() => {
+                      setShowNewKey(true);
+                      if (!newKeyName) setNewKeyName(name.trim() ? `${name.trim()}-ssh` : '');
+                    }}
+                  >
+                    <KeyRound className="size-3.5" /> Generate new SSH key
+                  </Button>
+                ) : (
+                  <div className="border-border bg-secondary/40 space-y-3 rounded-md border p-3">
+                    <p className="text-muted-foreground text-[11px] leading-relaxed">
+                      Creates an ed25519 keypair in this workspace and selects it for this server.
+                      Copy the public key onto the host before Connect.
+                    </p>
+                    <div className="space-y-2">
+                      <Label htmlFor="s-key-name">Key name</Label>
+                      <Input
+                        id="s-key-name"
+                        value={newKeyName}
+                        onChange={(e) => setNewKeyName(e.target.value)}
+                        placeholder="production-server"
+                      />
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <Button
+                        type="button"
+                        size="sm"
+                        onClick={() => createKeyMut.mutate()}
+                        disabled={createKeyMut.isPending}
+                      >
+                        {createKeyMut.isPending ? 'Generating…' : 'Generate & use'}
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => {
+                          setShowNewKey(false);
+                          setNewKeyName('');
+                        }}
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  </div>
+                )}
+
+                {createdPublicKey ? (
+                  <div className="border-border bg-[#0a0f0c] space-y-2 rounded-md border p-3">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-muted-foreground font-mono text-[10px] tracking-wide uppercase">
+                        Public key — add to server
+                      </span>
+                      <Button type="button" size="sm" variant="outline" onClick={() => void copyPublicKey()}>
+                        {copiedPub ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+                        {copiedPub ? 'Copied' : 'Copy'}
+                      </Button>
+                    </div>
+                    <code className="text-phosphor/90 block max-h-24 overflow-auto break-all font-mono text-[10.5px] leading-relaxed">
+                      {createdPublicKey}
+                    </code>
+                    <p className="text-muted-foreground text-[11px] leading-relaxed">
+                      On the host (as <span className="text-foreground/80">{user || 'root'}</span>):
+                      append this line to{' '}
+                      <code className="text-[10.5px]">~/.ssh/authorized_keys</code>, then continue
+                      with Add server → Connect.
+                    </p>
+                  </div>
+                ) : null}
               </div>
               <div className="space-y-2">
-                <Label>Gateway type</Label>
+                <div className="flex min-w-0 items-center gap-1.5">
+                  <Label>Gateway type</Label>
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          className="text-muted-foreground hover:text-foreground shrink-0"
+                          aria-label="About gateway type"
+                        >
+                          <CircleHelp className="size-3.5" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="top" className="max-w-xs text-left leading-relaxed">
+                        Reverse proxy Peon installs on this server to route public HTTPS domains to
+                        your apps (Traefik by default). Choose None if you only need SSH access or
+                        private networking.
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                </div>
                 <SearchableSelect
                   value={proxyType}
                   onValueChange={(v) => setProxyType(v as ProxyType)}
@@ -150,11 +320,6 @@ export default function ServersPage() {
                     { value: 'NONE', label: 'None' },
                   ]}
                 />
-                <p className="text-muted-foreground text-xs leading-relaxed">
-                  Reverse proxy Peon installs on this server to route public HTTPS domains to your
-                  apps (Traefik by default). Choose <span className="text-foreground/80">None</span>{' '}
-                  if you only need SSH access or private networking.
-                </p>
               </div>
             </div>
         </ModalBody>
@@ -192,7 +357,7 @@ export default function ServersPage() {
         <EmptyState
           icon={Server}
           title="No servers yet"
-          description="connect a server over ssh to start deploying your services."
+          description="add a linux host over ssh — you’ll need an ssh key (generate one in the form or under Keys & Tokens)."
           action={
             <Button onClick={() => setOpen(true)}>
               <Plus className="size-4" /> Add server

--- a/src/app/api/services/[serviceId]/backups/[backupId]/executions/route.ts
+++ b/src/app/api/services/[serviceId]/backups/[backupId]/executions/route.ts
@@ -6,9 +6,19 @@ import { BackupModule } from '@/services/internal/backup/module';
 
 type Ctx = { params: Promise<{ serviceId: string; backupId: string }> };
 
-export const GET = route(async (_req: NextRequest, { params }: Ctx) => {
+export const GET = route(async (request: NextRequest, { params }: Ctx) => {
   const { serviceId, backupId } = await params;
   const projectId = await ServiceModule.projectIdFor(serviceId);
   await requireProjectAccess(projectId);
-  return ok(await BackupModule.listExecutions(serviceId, backupId));
+
+  const limitRaw = request.nextUrl.searchParams.get('limit');
+  const limit = limitRaw ? Number(limitRaw) : 5;
+  const cursor = request.nextUrl.searchParams.get('cursor');
+
+  return ok(
+    await BackupModule.listExecutions(serviceId, backupId, {
+      limit: Number.isFinite(limit) ? limit : 5,
+      cursor,
+    }),
+  );
 });

--- a/src/app/api/services/[serviceId]/backups/download/route.ts
+++ b/src/app/api/services/[serviceId]/backups/download/route.ts
@@ -1,0 +1,37 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { route } from '@/lib/http/response';
+import { requireProjectManage } from '@/lib/auth/access';
+import { ServiceModule } from '@/services/internal/service/service';
+import { openBackupDownload } from '@/services/internal/backup/engine';
+import { ValidationError } from '@/lib/errors';
+
+type Ctx = { params: Promise<{ serviceId: string }> };
+
+export const runtime = 'nodejs';
+export const maxDuration = 300;
+
+/** Download a successful backup dump from the managed server. */
+export const GET = route(async (request: NextRequest, { params }: Ctx) => {
+  const { serviceId } = await params;
+  const projectId = await ServiceModule.projectIdFor(serviceId);
+  await requireProjectManage(projectId);
+
+  const filename = request.nextUrl.searchParams.get('filename')?.trim();
+  if (!filename) throw new ValidationError('filename query parameter is required.');
+
+  const { stream, filename: safeName, contentType, size } = await openBackupDownload(
+    serviceId,
+    filename,
+  );
+
+  return new NextResponse(stream, {
+    status: 200,
+    headers: {
+      'Content-Type': contentType,
+      'Content-Disposition': `attachment; filename="${safeName}"`,
+      'Content-Length': String(size),
+      'Cache-Control': 'no-store',
+    },
+  });
+});

--- a/src/app/api/services/[serviceId]/backups/restore/route.ts
+++ b/src/app/api/services/[serviceId]/backups/restore/route.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { ok, route } from '@/lib/http/response';
 import { requireProjectManage } from '@/lib/auth/access';
 import { ServiceModule } from '@/services/internal/service/service';
-import { runRestore } from '@/services/internal/backup/engine';
+import { BackupModule } from '@/services/internal/backup/module';
 
 type Ctx = { params: Promise<{ serviceId: string }> };
 
@@ -14,6 +14,5 @@ export const POST = route(async (request: NextRequest, { params }: Ctx) => {
   const projectId = await ServiceModule.projectIdFor(serviceId);
   await requireProjectManage(projectId);
   const { filename } = restoreSchema.parse(await request.json());
-  await runRestore(serviceId, filename);
-  return ok({ restored: true, filename });
+  return ok(await BackupModule.queueRestore(serviceId, filename));
 });

--- a/src/components/app/run-output.tsx
+++ b/src/components/app/run-output.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { parseRunOutput, type RunOutputBlock } from '@/lib/format-run-output';
+
+const COLLAPSE_CHARS = 480;
+
+function OutputBlockView({ block }: { block: RunOutputBlock }) {
+  const long = block.text.length > COLLAPSE_CHARS || block.text.split('\n').length > 12;
+  const [expanded, setExpanded] = useState(!long);
+  const shown = expanded ? block.text : `${block.text.slice(0, COLLAPSE_CHARS).trimEnd()}…`;
+
+  return (
+    <div className="overflow-hidden rounded-md border border-border/60 bg-[#0a0f0c]">
+      <div className="flex items-center justify-between gap-2 border-b border-border/40 px-2.5 py-1">
+        <span className="text-muted-foreground font-mono text-[10px] tracking-wide uppercase">
+          {block.label}
+        </span>
+        {long ? (
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            className="text-muted-foreground hover:text-foreground inline-flex items-center gap-0.5 text-[10px] transition-colors"
+          >
+            {expanded ? (
+              <>
+                <ChevronDown className="size-3" /> collapse
+              </>
+            ) : (
+              <>
+                <ChevronRight className="size-3" /> expand
+              </>
+            )}
+          </button>
+        ) : null}
+      </div>
+      <pre
+        className={cn(
+          'max-h-64 overflow-auto px-2.5 py-2 font-mono text-[10.5px] leading-relaxed whitespace-pre-wrap',
+          block.kind === 'json' ? 'text-phosphor/90' : 'text-neutral-300',
+        )}
+      >
+        {shown}
+      </pre>
+    </div>
+  );
+}
+
+/** Renders task/cron stdout: pretty JSON when possible, otherwise plain output. */
+export function RunOutput({
+  message,
+  className,
+}: {
+  message: string | null | undefined;
+  className?: string;
+}) {
+  const parsed = parseRunOutput(message);
+
+  if (parsed.empty) {
+    return (
+      <div
+        className={cn(
+          'text-muted-foreground rounded-md border border-dashed border-border/50 px-2.5 py-2 text-[10.5px] italic',
+          className,
+        )}
+      >
+        no output
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('space-y-1.5', className)}>
+      {parsed.blocks.map((block, i) => (
+        <OutputBlockView key={`${block.kind}-${i}`} block={block} />
+      ))}
+    </div>
+  );
+}

--- a/src/lib/__tests__/format-run-output.test.ts
+++ b/src/lib/__tests__/format-run-output.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { parseRunOutput } from '../format-run-output';
+
+describe('parseRunOutput', () => {
+  it('treats blank output as empty', () => {
+    expect(parseRunOutput(null)).toEqual({ empty: true, blocks: [] });
+    expect(parseRunOutput('   ')).toEqual({ empty: true, blocks: [] });
+  });
+
+  it('pretty-prints pure JSON', () => {
+    const parsed = parseRunOutput('{"success":true,"data":{"n":1}}');
+    expect(parsed.empty).toBe(false);
+    if (parsed.empty) return;
+    expect(parsed.blocks).toHaveLength(1);
+    expect(parsed.blocks[0]?.kind).toBe('json');
+    expect(parsed.blocks[0]?.text).toContain('\n');
+    expect(parsed.blocks[0]?.text).toContain('"success": true');
+  });
+
+  it('splits leading JSON from trailing text (e.g. curl progress)', () => {
+    const raw =
+      '{"success":true,"data":{"message":"ok"}}\n  % Total    % Received\n100   123';
+    const parsed = parseRunOutput(raw);
+    expect(parsed.empty).toBe(false);
+    if (parsed.empty) return;
+    expect(parsed.blocks).toHaveLength(2);
+    expect(parsed.blocks[0]).toMatchObject({ kind: 'json', label: 'json' });
+    expect(parsed.blocks[1]).toMatchObject({ kind: 'text', label: 'output' });
+    expect(parsed.blocks[1]?.text).toContain('% Total');
+  });
+
+  it('keeps plain text as a single block', () => {
+    const parsed = parseRunOutput('hello\nworld');
+    expect(parsed).toEqual({
+      empty: false,
+      blocks: [{ kind: 'text', label: 'output', text: 'hello\nworld' }],
+    });
+  });
+});

--- a/src/lib/deploy/__tests__/sync-repo-script.test.ts
+++ b/src/lib/deploy/__tests__/sync-repo-script.test.ts
@@ -8,6 +8,7 @@ describe('buildGitSyncScript', () => {
       repo: 'https://github.com/acme/app.git',
       branch: 'main',
     });
+    expect(script).toContain('COMMIT_SHA=""');
     expect(script).toContain('git fetch --depth 1 origin "$BRANCH"');
     expect(script).toContain('git checkout -B "$BRANCH" FETCH_HEAD');
     expect(script).not.toContain('git reset --hard origin/');
@@ -24,5 +25,19 @@ describe('buildGitSyncScript', () => {
     expect(script).toContain('FORCE_CLEAN=1');
     expect(script).toContain('Force rebuild: clearing cached source');
     expect(script).toContain('rm -rf "$SRC"');
+  });
+
+  it('fetches and checks out a specific commit when commitSha is set (rollback)', () => {
+    const script = buildGitSyncScript({
+      src: '/data/peon/services/app/src',
+      repo: 'https://github.com/acme/app.git',
+      branch: 'main',
+      commitSha: 'abc123def456',
+      forceClean: true,
+    });
+    expect(script).toContain('COMMIT_SHA="abc123def456"');
+    expect(script).toContain('Checking out commit $COMMIT_SHA');
+    expect(script).toContain('git fetch --depth 1 origin "$COMMIT_SHA"');
+    expect(script).toContain('git checkout -f FETCH_HEAD');
   });
 });

--- a/src/lib/deploy/sync-repo-script.ts
+++ b/src/lib/deploy/sync-repo-script.ts
@@ -6,10 +6,13 @@ export function buildGitSyncScript(opts: {
   gitSshPrefix?: string;
   keyCleanup?: string;
   forceClean?: boolean;
+  /** When set (e.g. rollback), fetch and check out this commit instead of the branch tip. */
+  commitSha?: string | null;
 }): string {
   const src = JSON.stringify(opts.src);
   const repo = JSON.stringify(opts.repo);
   const branch = JSON.stringify(opts.branch);
+  const commitSha = JSON.stringify((opts.commitSha ?? '').trim());
   const gitSshPrefix = opts.gitSshPrefix ?? '';
   const keyCleanup = opts.keyCleanup ?? 'true';
   const forceClean = opts.forceClean ? '1' : '0';
@@ -19,6 +22,7 @@ set -e
 SRC=${src}
 REPO_URL=${repo}
 BRANCH=${branch}
+COMMIT_SHA=${commitSha}
 FORCE_CLEAN=${forceClean}
 
 if [ "$FORCE_CLEAN" = "1" ] && [ -d "$SRC" ]; then
@@ -26,7 +30,24 @@ if [ "$FORCE_CLEAN" = "1" ] && [ -d "$SRC" ]; then
   rm -rf "$SRC"
 fi
 
-if [ -d "$SRC/.git" ]; then
+if [ -n "$COMMIT_SHA" ]; then
+  echo "Checking out commit $COMMIT_SHA…"
+  if [ -d "$SRC/.git" ]; then
+    cd "$SRC"
+    ${gitSshPrefix}git remote set-url origin "$REPO_URL"
+  else
+    rm -rf "$SRC"
+    mkdir -p "$SRC"
+    cd "$SRC"
+    git init
+    git remote add origin "$REPO_URL"
+  fi
+  # Shallow-fetch the exact commit (GitHub/GitLab support fetch-by-sha).
+  ${gitSshPrefix}git fetch --depth 1 origin "$COMMIT_SHA"
+  git checkout -f FETCH_HEAD
+  git reset --hard FETCH_HEAD
+  git clean -fd
+elif [ -d "$SRC/.git" ]; then
   cd "$SRC"
   ${gitSshPrefix}git remote set-url origin "$REPO_URL"
   # Fetch the branch tip explicitly — shallow clones can leave a stale origin/<branch>.

--- a/src/lib/docker/__tests__/databases.test.ts
+++ b/src/lib/docker/__tests__/databases.test.ts
@@ -4,6 +4,7 @@ import {
   resolveDatabaseDataPath,
   POSTGRES_DATA_PATH_LEGACY,
   POSTGRES_DATA_PATH_V18,
+  DATABASE_ENGINES,
 } from '../databases';
 
 describe('parsePostgresMajorVersion', () => {
@@ -50,5 +51,36 @@ describe('resolveDatabaseDataPath', () => {
   it('leaves non-Postgres engines unchanged', () => {
     expect(resolveDatabaseDataPath('MYSQL', 'mysql:8')).toBe('/var/lib/mysql');
     expect(resolveDatabaseDataPath('REDIS', 'redis:7-alpine')).toBe('/data');
+  });
+});
+
+describe('dumpCommand dumpAll', () => {
+  const creds = {
+    username: 'peon',
+    password: 'secret',
+    database: 'appdb',
+    rootPassword: 'rootsecret',
+  };
+
+  it('defaults Postgres to single-DB dump when dumpAll is unset', () => {
+    expect(DATABASE_ENGINES.POSTGRESQL.dumpCommand?.(creds)).toBe('pg_dump -U peon appdb');
+  });
+
+  it('uses pg_dumpall for Postgres when dumpAll is true', () => {
+    expect(DATABASE_ENGINES.POSTGRESQL.dumpCommand?.(creds, { dumpAll: true })).toBe(
+      'pg_dumpall -U peon',
+    );
+    expect(DATABASE_ENGINES.POSTGRESQL.restoreCommand?.(creds, { dumpAll: true })).toBe(
+      'psql -U peon -d postgres',
+    );
+  });
+
+  it('uses --all-databases for MySQL/MariaDB when dumpAll is true', () => {
+    expect(DATABASE_ENGINES.MYSQL.dumpCommand?.(creds, { dumpAll: true })).toBe(
+      'mysqldump -u root -prootsecret --all-databases',
+    );
+    expect(DATABASE_ENGINES.MARIADB.dumpCommand?.(creds, { dumpAll: true })).toBe(
+      'mariadb-dump -u root -prootsecret --all-databases',
+    );
   });
 });

--- a/src/lib/docker/databases.ts
+++ b/src/lib/docker/databases.ts
@@ -8,6 +8,11 @@ export interface DbCredentialField {
   isPassword?: boolean;
 }
 
+export interface DumpOptions {
+  /** When true, dump/restore every database in the instance (default for schedules). */
+  dumpAll?: boolean;
+}
+
 export interface DatabaseEngineSpec {
   engine: DatabaseEngine;
   label: string;
@@ -25,9 +30,9 @@ export interface DatabaseEngineSpec {
   /** Builds a connection URL, or null when the engine has no URL scheme. */
   connectionUrl?: (creds: DbCredentials, host: string, port: number) => string;
   /** Shell command (inside container) to produce a logical dump to stdout. */
-  dumpCommand?: (creds: DbCredentials) => string;
+  dumpCommand?: (creds: DbCredentials, opts?: DumpOptions) => string;
   /** Command to restore from a dump piped over stdin. */
-  restoreCommand?: (creds: DbCredentials) => string;
+  restoreCommand?: (creds: DbCredentials, opts?: DumpOptions) => string;
 }
 
 export interface DbCredentials {
@@ -87,8 +92,14 @@ export const DATABASE_ENGINES: Record<DatabaseEngine, DatabaseEngineSpec> = {
     ],
     connectionUrl: (c, host, port) =>
       `postgres://${c.username ?? 'postgres'}:${c.password ?? ''}@${host}:${port}/${c.database ?? 'postgres'}`,
-    dumpCommand: (c) => `pg_dump -U ${c.username ?? 'postgres'} ${c.database ?? 'postgres'}`,
-    restoreCommand: (c) => `psql -U ${c.username ?? 'postgres'} ${c.database ?? 'postgres'}`,
+    dumpCommand: (c, opts) =>
+      opts?.dumpAll
+        ? `pg_dumpall -U ${c.username ?? 'postgres'}`
+        : `pg_dump -U ${c.username ?? 'postgres'} ${c.database ?? 'postgres'}`,
+    restoreCommand: (c, opts) =>
+      opts?.dumpAll
+        ? `psql -U ${c.username ?? 'postgres'} -d postgres`
+        : `psql -U ${c.username ?? 'postgres'} ${c.database ?? 'postgres'}`,
   },
   MYSQL: {
     engine: 'MYSQL',
@@ -110,8 +121,16 @@ export const DATABASE_ENGINES: Record<DatabaseEngine, DatabaseEngineSpec> = {
     ],
     connectionUrl: (c, host, port) =>
       `mysql://${c.username ?? 'mysql'}:${c.password ?? ''}@${host}:${port}/${c.database ?? 'app'}`,
-    dumpCommand: (c) => `mysqldump -u root -p${c.rootPassword ?? c.password} ${c.database ?? 'app'}`,
-    restoreCommand: (c) => `mysql -u root -p${c.rootPassword ?? c.password} ${c.database ?? 'app'}`,
+    dumpCommand: (c, opts) => {
+      const auth = `-u root -p${c.rootPassword ?? c.password}`;
+      return opts?.dumpAll
+        ? `mysqldump ${auth} --all-databases`
+        : `mysqldump ${auth} ${c.database ?? 'app'}`;
+    },
+    restoreCommand: (c, opts) => {
+      const auth = `-u root -p${c.rootPassword ?? c.password}`;
+      return opts?.dumpAll ? `mysql ${auth}` : `mysql ${auth} ${c.database ?? 'app'}`;
+    },
   },
   MARIADB: {
     engine: 'MARIADB',
@@ -133,8 +152,16 @@ export const DATABASE_ENGINES: Record<DatabaseEngine, DatabaseEngineSpec> = {
     ],
     connectionUrl: (c, host, port) =>
       `mysql://${c.username ?? 'mariadb'}:${c.password ?? ''}@${host}:${port}/${c.database ?? 'app'}`,
-    dumpCommand: (c) => `mariadb-dump -u root -p${c.rootPassword ?? c.password} ${c.database ?? 'app'}`,
-    restoreCommand: (c) => `mariadb -u root -p${c.rootPassword ?? c.password} ${c.database ?? 'app'}`,
+    dumpCommand: (c, opts) => {
+      const auth = `-u root -p${c.rootPassword ?? c.password}`;
+      return opts?.dumpAll
+        ? `mariadb-dump ${auth} --all-databases`
+        : `mariadb-dump ${auth} ${c.database ?? 'app'}`;
+    },
+    restoreCommand: (c, opts) => {
+      const auth = `-u root -p${c.rootPassword ?? c.password}`;
+      return opts?.dumpAll ? `mariadb ${auth}` : `mariadb ${auth} ${c.database ?? 'app'}`;
+    },
   },
   MONGODB: {
     engine: 'MONGODB',
@@ -154,6 +181,7 @@ export const DATABASE_ENGINES: Record<DatabaseEngine, DatabaseEngineSpec> = {
     ],
     connectionUrl: (c, host, port) =>
       `mongodb://${c.username ?? 'root'}:${c.password ?? ''}@${host}:${port}/${c.database ?? 'app'}?authSource=admin`,
+    // mongodump/mongorestore without --db always cover the whole instance.
     dumpCommand: () => `mongodump --archive`,
     restoreCommand: () => `mongorestore --archive`,
   },

--- a/src/lib/format-run-output.ts
+++ b/src/lib/format-run-output.ts
@@ -1,0 +1,79 @@
+export type RunOutputBlock =
+  | { kind: 'json'; label: string; text: string }
+  | { kind: 'text'; label: string; text: string };
+
+export type ParsedRunOutput =
+  | { empty: true; blocks: [] }
+  | { empty: false; blocks: RunOutputBlock[] };
+
+/**
+ * Split task/cron stdout into display blocks. Prefers pretty JSON when the
+ * payload (or a leading JSON value) can be parsed; leftover text stays as-is.
+ */
+export function parseRunOutput(raw: string | null | undefined): ParsedRunOutput {
+  const trimmed = (raw ?? '').trim();
+  if (!trimmed) return { empty: true, blocks: [] };
+
+  const asJson = tryPrettyJson(trimmed);
+  if (asJson) {
+    return { empty: false, blocks: [{ kind: 'json', label: 'json', text: asJson }] };
+  }
+
+  const leading = extractLeadingJson(trimmed);
+  if (leading) {
+    const blocks: RunOutputBlock[] = [
+      { kind: 'json', label: 'json', text: leading.pretty },
+    ];
+    if (leading.rest) {
+      blocks.push({ kind: 'text', label: 'output', text: leading.rest });
+    }
+    return { empty: false, blocks };
+  }
+
+  return { empty: false, blocks: [{ kind: 'text', label: 'output', text: trimmed }] };
+}
+
+function tryPrettyJson(value: string): string | null {
+  try {
+    return JSON.stringify(JSON.parse(value), null, 2);
+  } catch {
+    return null;
+  }
+}
+
+/** Find a JSON object/array that starts at index 0 (brace-balanced). */
+function extractLeadingJson(value: string): { pretty: string; rest: string } | null {
+  const start = value[0];
+  if (start !== '{' && start !== '[') return null;
+  const close = start === '{' ? '}' : ']';
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+
+  for (let i = 0; i < value.length; i++) {
+    const ch = value[i];
+    if (inString) {
+      if (escape) {
+        escape = false;
+      } else if (ch === '\\') {
+        escape = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (ch === start) depth++;
+    else if (ch === close) depth--;
+    if (depth === 0) {
+      const candidate = value.slice(0, i + 1);
+      const pretty = tryPrettyJson(candidate);
+      if (!pretty) return null;
+      return { pretty, rest: value.slice(i + 1).trim() };
+    }
+  }
+  return null;
+}

--- a/src/lib/mcp/tools/backups.ts
+++ b/src/lib/mcp/tools/backups.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { BackupModule } from '@/services/internal/backup/module';
-import { runRestore } from '@/services/internal/backup/engine';
 import { upsertBackupSchema } from '@/schemas/service.schema';
 import { buildCatalogFromLegacy } from '@/lib/mcp/catalog/legacy';
 import type { CatalogTool } from '@/lib/mcp/catalog/types';
@@ -23,7 +22,7 @@ export function registerBackupTools(server: McpServer, _ctx: McpContext, access:
 
   server.tool(
     'create_backup',
-    'Create a backup schedule. Requires manage access.',
+    'Create a backup schedule. Requires manage access. By default dumps the entire database instance (all DBs).',
     {
       serviceId: z.string().describe('The service ID'),
       frequency: z.string().min(1).describe('5-field cron expression'),
@@ -37,6 +36,10 @@ export function registerBackupTools(server: McpServer, _ctx: McpContext, access:
         .max(1000)
         .optional()
         .describe('Local retention count (default 7)'),
+      dumpAll: z
+        .boolean()
+        .optional()
+        .describe('Dump entire instance / all databases (default true). Set false for configured DB only.'),
     },
     safe(async ({ serviceId, ...rest }) => {
       await serviceAccess(serviceId, true);
@@ -56,6 +59,7 @@ export function registerBackupTools(server: McpServer, _ctx: McpContext, access:
       saveS3: z.boolean().optional(),
       s3StorageId: z.string().nullable().optional(),
       retentionAmountLocal: z.number().int().min(0).max(1000).optional(),
+      dumpAll: z.boolean().optional().describe('Dump entire instance when true'),
     },
     safe(async ({ serviceId, backupId, ...rest }) => {
       await serviceAccess(serviceId, true);
@@ -92,28 +96,29 @@ export function registerBackupTools(server: McpServer, _ctx: McpContext, access:
 
   server.tool(
     'list_backup_executions',
-    'List recent backup executions.',
+    'List recent backup executions (paginated, newest first).',
     {
       serviceId: z.string().describe('The service ID'),
       backupId: z.string().describe('The backup ID'),
+      limit: z.number().int().min(1).max(50).optional().describe('Page size (default 5)'),
+      cursor: z.string().optional().describe('Cursor from a previous page nextCursor'),
     },
-    safe(async ({ serviceId, backupId }) => {
+    safe(async ({ serviceId, backupId, limit, cursor }) => {
       await serviceAccess(serviceId);
-      return json(await BackupModule.listExecutions(serviceId, backupId));
+      return json(await BackupModule.listExecutions(serviceId, backupId, { limit, cursor }));
     }),
   );
 
   server.tool(
     'restore_backup',
-    'Restore a database service from a backup filename. Requires manage access.',
+    'Queue a database restore from a backup filename. Requires manage access. Runs asynchronously on the worker.',
     {
       serviceId: z.string().describe('The service ID'),
       filename: z.string().min(1).describe('Backup filename to restore'),
     },
     safe(async ({ serviceId, filename }) => {
       await serviceAccess(serviceId, true);
-      await runRestore(serviceId, filename);
-      return json({ restored: true, filename });
+      return json(await BackupModule.queueRestore(serviceId, filename));
     }),
   );
 }

--- a/src/lib/queue/messages.ts
+++ b/src/lib/queue/messages.ts
@@ -42,6 +42,12 @@ export interface BackupJob {
   executionId: string;
 }
 
+export interface BackupRestoreJob {
+  type: 'backup.restore';
+  serviceId: string;
+  filename: string;
+}
+
 export interface TaskJob {
   type: 'task.run';
   taskId: string;
@@ -70,6 +76,7 @@ export type QueueMessage =
   | ServiceControlJob
   | DatabaseProvisionJob
   | BackupJob
+  | BackupRestoreJob
   | TaskJob
   | ServerCleanupJob
   | EmailSendJob;

--- a/src/lib/ssh/pool.ts
+++ b/src/lib/ssh/pool.ts
@@ -191,6 +191,18 @@ class SshPool {
     });
   }
 
+  /** Download a remote file to a local path over SFTP. */
+  async getFile(target: SshTarget, remotePath: string, localPath: string): Promise<void> {
+    if (isE2eMode()) {
+      const { writeFile } = await import('node:fs/promises');
+      await writeFile(localPath, '-- e2e backup stub\n');
+      return;
+    }
+    await this.withFreshConnection(target, async (ssh) => {
+      await ssh.getFile(localPath, remotePath);
+    });
+  }
+
   /** Verify connectivity. Returns false on any SSH failure. */
   async ping(target: SshTarget): Promise<boolean> {
     try {

--- a/src/schemas/service.schema.ts
+++ b/src/schemas/service.schema.ts
@@ -202,6 +202,8 @@ export const upsertBackupSchema = z.object({
   saveS3: z.boolean().default(false),
   s3StorageId: z.string().nullable().optional(),
   retentionAmountLocal: z.number().int().min(0).max(1000).default(7),
+  /** Entire instance (all DBs) vs configured database only. Default: entire instance. */
+  dumpAll: z.boolean().default(true),
 });
 
 export type UpsertBackupInput = z.infer<typeof upsertBackupSchema>;

--- a/src/services/api/service.ts
+++ b/src/services/api/service.ts
@@ -303,6 +303,7 @@ export interface ScheduledBackupItem {
   s3StorageId: string | null;
   s3Storage: { id: string; name: string } | null;
   retentionAmountLocal: number;
+  dumpAll: boolean;
   createdAt: string;
   _count: { executions: number };
 }
@@ -313,6 +314,8 @@ export interface BackupExecution {
   message: string | null;
   filename: string | null;
   databaseName: string | null;
+  dumpAll: boolean;
+  size: string | null;
   s3Uploaded: boolean;
   startedAt: string;
   finishedAt: string | null;
@@ -338,12 +341,39 @@ export function runBackupNow(serviceId: string, backupId: string) {
   return unwrap(api.post(`/services/${serviceId}/backups/${backupId}/run`));
 }
 
-export function listBackupExecutions(serviceId: string, backupId: string) {
-  return unwrap<BackupExecution[]>(api.get(`/services/${serviceId}/backups/${backupId}/executions`));
+export function listBackupExecutions(
+  serviceId: string,
+  backupId: string,
+  opts?: { limit?: number; cursor?: string | null },
+) {
+  return unwrap<{ items: BackupExecution[]; nextCursor: string | null }>(
+    api.get(`/services/${serviceId}/backups/${backupId}/executions`, {
+      params: {
+        ...(opts?.limit != null ? { limit: opts.limit } : {}),
+        ...(opts?.cursor ? { cursor: opts.cursor } : {}),
+      },
+    }),
+  );
 }
 
 export function restoreBackup(serviceId: string, filename: string) {
   return unwrap(api.post(`/services/${serviceId}/backups/restore`, { filename }));
+}
+
+/** Download a backup dump file from the managed server. */
+export async function downloadBackup(serviceId: string, filename: string): Promise<void> {
+  const res = await api.get(`/services/${serviceId}/backups/download`, {
+    params: { filename },
+    responseType: 'blob',
+  });
+  const disposition = res.headers['content-disposition'] as string | undefined;
+  const name = disposition?.match(/filename="([^"]+)"/)?.[1] ?? filename;
+  const url = URL.createObjectURL(res.data);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = name;
+  anchor.click();
+  URL.revokeObjectURL(url);
 }
 
 export interface ScheduledTaskItem {

--- a/src/services/internal/backup/engine.ts
+++ b/src/services/internal/backup/engine.ts
@@ -1,3 +1,8 @@
+import { createReadStream } from 'node:fs';
+import { mkdtemp, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
 import { prisma } from '@/lib/prisma';
 import { sshPool, sshTargetForServer } from '@/lib/ssh';
 import { decrypt } from '@/lib/crypto/encryption';
@@ -6,6 +11,10 @@ import { containerName } from '@/lib/docker/naming';
 import { uploadFileFromServer } from '@/services/external/s3/backup';
 import { notifyService } from '@/services/internal/notifications/events';
 import { ValidationError, NotFoundError } from '@/lib/errors';
+
+function assertSafeBackupFilename(filename: string): void {
+  if (/[/\\]|\.\./.test(filename)) throw new ValidationError('Invalid backup filename.');
+}
 
 export async function runBackup(backupId: string, executionId: string): Promise<void> {
   const backup = await prisma.scheduledBackup.findUnique({
@@ -19,6 +28,7 @@ export async function runBackup(backupId: string, executionId: string): Promise<
   const spec = engineSpec(svc.databaseEngine ?? 'POSTGRESQL');
   if (!spec.dumpCommand) throw new Error(`Backups not supported for ${spec.label}.`);
 
+  const dumpAll = backup.dumpAll;
   const target = await sshTargetForServer(svc.serverId);
   const name = containerName(svc.name, svc.uuid);
   const creds = {
@@ -33,7 +43,7 @@ export async function runBackup(backupId: string, executionId: string): Promise<
   const remotePath = `/data/peon/backups/${filename}`;
 
   try {
-    const script = `mkdir -p /data/peon/backups && docker exec ${name} sh -c '${spec.dumpCommand(creds)}' > ${remotePath} && ls -la ${remotePath}`;
+    const script = `mkdir -p /data/peon/backups && docker exec ${name} sh -c '${spec.dumpCommand(creds, { dumpAll })}' > ${remotePath} && ls -la ${remotePath}`;
     const res = await sshPool.exec(target, script);
     if (res.code !== 0) throw new Error(res.stderr || 'Dump failed.');
 
@@ -43,12 +53,17 @@ export async function runBackup(backupId: string, executionId: string): Promise<
       s3Uploaded = true;
     }
 
+    const sizeRes = await sshPool.exec(target, `stat -c %s ${remotePath} 2>/dev/null || stat -f %z ${remotePath}`);
+    const sizeBytes = sizeRes.code === 0 ? sizeRes.stdout.trim() : null;
+
     await prisma.scheduledBackupExecution.update({
       where: { id: executionId },
       data: {
         status: 'SUCCESS',
         filename,
-        databaseName: svc.dbName,
+        databaseName: dumpAll ? '*' : svc.dbName,
+        dumpAll,
+        size: sizeBytes,
         s3Uploaded,
         finishedAt: new Date(),
       },
@@ -58,7 +73,7 @@ export async function runBackup(backupId: string, executionId: string): Promise<
 
     await notifyService(svc.id, 'backup_success', {
       subject: `Backup succeeded: ${svc.name}`,
-      text: `Database backup for "${svc.name}" completed (${filename})${s3Uploaded ? ' and was uploaded to S3' : ''}.`,
+      text: `Database backup for "${svc.name}" completed (${filename})${dumpAll ? ' [entire instance]' : ''}${s3Uploaded ? ' and was uploaded to S3' : ''}.`,
     });
   } catch (err) {
     await prisma.scheduledBackupExecution.update({
@@ -66,6 +81,7 @@ export async function runBackup(backupId: string, executionId: string): Promise<
       data: {
         status: 'FAILED',
         message: err instanceof Error ? err.message : String(err),
+        dumpAll,
         finishedAt: new Date(),
       },
     });
@@ -84,7 +100,7 @@ export async function runBackup(backupId: string, executionId: string): Promise<
  * running database container.
  */
 export async function runRestore(serviceId: string, filename: string): Promise<void> {
-  if (/[/\\]|\.\./.test(filename)) throw new ValidationError('Invalid backup filename.');
+  assertSafeBackupFilename(filename);
   const svc = await prisma.service.findUnique({ where: { id: serviceId } });
   if (!svc || svc.kind !== 'DATABASE' || !svc.serverId) {
     throw new ValidationError('Restore target is not a database.');
@@ -92,6 +108,12 @@ export async function runRestore(serviceId: string, filename: string): Promise<v
 
   const spec = engineSpec(svc.databaseEngine ?? 'POSTGRESQL');
   if (!spec.restoreCommand) throw new ValidationError(`Restore not supported for ${spec.label}.`);
+
+  const execution = await prisma.scheduledBackupExecution.findFirst({
+    where: { filename, backup: { serviceId }, status: 'SUCCESS' },
+    orderBy: { startedAt: 'desc' },
+  });
+  const dumpAll = execution?.dumpAll ?? true;
 
   const target = await sshTargetForServer(svc.serverId);
   const name = containerName(svc.name, svc.uuid);
@@ -106,9 +128,63 @@ export async function runRestore(serviceId: string, filename: string): Promise<v
   const check = await sshPool.exec(target, `test -f ${remotePath} && echo ok || echo missing`);
   if (!check.stdout.includes('ok')) throw new NotFoundError(`Backup file not found: ${filename}`);
 
-  const script = `docker exec -i ${name} sh -c '${spec.restoreCommand(creds)}' < ${remotePath}`;
+  const script = `docker exec -i ${name} sh -c '${spec.restoreCommand(creds, { dumpAll })}' < ${remotePath}`;
   const res = await sshPool.exec(target, script);
   if (res.code !== 0) throw new Error(res.stderr || 'Restore failed.');
+}
+
+/**
+ * Stream a local backup dump from the managed server to the caller.
+ * Returns a web ReadableStream; cleans up the temp file when the stream ends.
+ */
+export async function openBackupDownload(
+  serviceId: string,
+  filename: string,
+): Promise<{ stream: ReadableStream; filename: string; contentType: string; size: number }> {
+  assertSafeBackupFilename(filename);
+  const svc = await prisma.service.findUnique({ where: { id: serviceId } });
+  if (!svc || svc.kind !== 'DATABASE' || !svc.serverId) {
+    throw new ValidationError('Download target is not a database.');
+  }
+
+  const execution = await prisma.scheduledBackupExecution.findFirst({
+    where: { filename, backup: { serviceId }, status: 'SUCCESS' },
+  });
+  if (!execution) throw new NotFoundError('Backup execution not found for that filename.');
+
+  const target = await sshTargetForServer(svc.serverId);
+  const remotePath = `/data/peon/backups/${filename}`;
+  const check = await sshPool.exec(target, `test -f ${remotePath} && echo ok || echo missing`);
+  if (!check.stdout.includes('ok')) throw new NotFoundError(`Backup file not found: ${filename}`);
+
+  const dir = await mkdtemp(join(tmpdir(), 'peon-backup-'));
+  const localPath = join(dir, filename);
+  try {
+    await sshPool.getFile(target, remotePath, localPath);
+    const fileStat = await stat(localPath);
+    const nodeStream = createReadStream(localPath);
+    const cleanup = async () => {
+      nodeStream.destroy();
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    };
+    nodeStream.on('close', () => {
+      void cleanup();
+    });
+    nodeStream.on('error', () => {
+      void cleanup();
+    });
+
+    const webStream = Readable.toWeb(nodeStream) as ReadableStream;
+    return {
+      stream: webStream,
+      filename,
+      contentType: 'application/sql',
+      size: fileStat.size,
+    };
+  } catch (err) {
+    await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    throw err;
+  }
 }
 
 async function enforceRetention(backupId: string, target: Awaited<ReturnType<typeof sshTargetForServer>>) {

--- a/src/services/internal/backup/module.ts
+++ b/src/services/internal/backup/module.ts
@@ -46,6 +46,7 @@ export const BackupModule = {
         saveS3: input.saveS3,
         s3StorageId: input.saveS3 ? (input.s3StorageId ?? null) : null,
         retentionAmountLocal: input.retentionAmountLocal,
+        dumpAll: input.dumpAll,
       },
     });
     await recordServiceAudit(serviceId, {
@@ -69,6 +70,7 @@ export const BackupModule = {
         ...(input.retentionAmountLocal !== undefined
           ? { retentionAmountLocal: input.retentionAmountLocal }
           : {}),
+        ...(input.dumpAll !== undefined ? { dumpAll: input.dumpAll } : {}),
       },
     });
     await recordServiceAudit(serviceId, {
@@ -95,7 +97,7 @@ export const BackupModule = {
     const backup = await prisma.scheduledBackup.findFirst({ where: { id: backupId, serviceId } });
     if (!backup) throw new NotFoundError('Backup schedule not found.');
     const execution = await prisma.scheduledBackupExecution.create({
-      data: { backupId, status: 'RUNNING' },
+      data: { backupId, status: 'RUNNING', dumpAll: backup.dumpAll },
     });
     await enqueue({ type: 'backup.run', backupId, executionId: execution.id });
     await recordServiceAudit(serviceId, {
@@ -106,14 +108,51 @@ export const BackupModule = {
     return execution;
   },
 
-  async listExecutions(serviceId: string, backupId: string) {
+  /** Queue a restore from a local dump filename. */
+  async queueRestore(serviceId: string, filename: string) {
+    if (/[/\\]|\.\./.test(filename)) throw new ValidationError('Invalid backup filename.');
+    const svc = await this.assertBackupable(serviceId);
+    const spec = engineSpec(svc.databaseEngine!);
+    if (!spec.restoreCommand) {
+      throw new ValidationError(`Restore is not supported for ${spec.label}.`);
+    }
+
+    const execution = await prisma.scheduledBackupExecution.findFirst({
+      where: { filename, backup: { serviceId }, status: 'SUCCESS' },
+      orderBy: { startedAt: 'desc' },
+      select: { id: true },
+    });
+    if (!execution) throw new NotFoundError('Backup execution not found for that filename.');
+
+    await enqueue({ type: 'backup.restore', serviceId, filename });
+    await recordServiceAudit(serviceId, {
+      action: 'service.backup.restore',
+      summary: 'Queued backup restore',
+      metadata: { filename },
+    });
+    return { queued: true as const, filename };
+  },
+
+  async listExecutions(
+    serviceId: string,
+    backupId: string,
+    opts: { limit?: number; cursor?: string | null } = {},
+  ) {
     const backup = await prisma.scheduledBackup.findFirst({ where: { id: backupId, serviceId } });
     if (!backup) throw new NotFoundError('Backup schedule not found.');
-    return prisma.scheduledBackupExecution.findMany({
+
+    const limit = Math.min(Math.max(opts.limit ?? 5, 1), 50);
+    const rows = await prisma.scheduledBackupExecution.findMany({
       where: { backupId },
-      orderBy: { startedAt: 'desc' },
-      take: 30,
+      orderBy: [{ startedAt: 'desc' }, { id: 'desc' }],
+      take: limit + 1,
+      ...(opts.cursor ? { cursor: { id: opts.cursor }, skip: 1 } : {}),
     });
+
+    const hasMore = rows.length > limit;
+    const items = hasMore ? rows.slice(0, limit) : rows;
+    const nextCursor = hasMore ? (items[items.length - 1]?.id ?? null) : null;
+    return { items, nextCursor };
   },
 };
 

--- a/src/services/internal/deploy/engine.ts
+++ b/src/services/internal/deploy/engine.ts
@@ -72,7 +72,7 @@ async function syncRepo(
   svc: FullService,
   dir: string,
   log: (m: string) => void,
-  opts: { forceClean?: boolean; branch?: string | null } = {},
+  opts: { forceClean?: boolean; branch?: string | null; commitSha?: string | null } = {},
 ) {
   let repo = svc.gitRepository!;
   const branch = opts.branch || svc.gitBranch || 'main';
@@ -100,6 +100,10 @@ async function syncRepo(
     keyCleanup = `rm -f ${keyPath}`;
   }
 
+  if (opts.commitSha?.trim()) {
+    log(`Rolling back / pinning to commit ${opts.commitSha.trim().slice(0, 12)}…`);
+  }
+
   const script = buildGitSyncScript({
     src,
     repo,
@@ -107,6 +111,7 @@ async function syncRepo(
     gitSshPrefix,
     keyCleanup,
     forceClean: opts.forceClean,
+    commitSha: opts.commitSha,
   });
   const res = await sshPool.execStream(target, script, (c) => log(c.trimEnd()));
   if (res.code !== 0) throw new Error('Git clone/pull failed.');
@@ -617,6 +622,8 @@ export async function runDeployment(deploymentId: string): Promise<void> {
           const sha = await syncRepo(target, svc, dir, log, {
             forceClean: deployment.forceRebuild || isPreview,
             branch: isPreview ? preview?.headBranch : null,
+            // Rollback (and any pinned deploy) must check out this SHA, not branch tip.
+            commitSha: deployment.commitSha,
           });
           await assertNotCancelled(deploymentId);
           // Only persist commit metadata while still in progress (cancel may have won the race).

--- a/src/test/integration/api/services.integration.test.ts
+++ b/src/test/integration/api/services.integration.test.ts
@@ -125,17 +125,40 @@ describe('service API', () => {
       ).status,
     ).toBe(200);
     expect((await http.post(`${backupPath}/run`)).status).toBe(200);
-    expect((await http.get(`${backupPath}/executions`)).status).toBe(200);
+    const executions = await http.get(`${backupPath}/executions`);
+    expect(executions.status).toBe(200);
+    expect(executions.body.data.items).toBeDefined();
+    expect(executions.body.data.nextCursor).toBeNull();
+
+    await prisma.scheduledBackupExecution.create({
+      data: {
+        backupId: backup.body.data.id as string,
+        status: 'SUCCESS',
+        filename: 'backup.sql',
+        dumpAll: false,
+        finishedAt: new Date(),
+      },
+    });
+    const restore = await http.post(`${path}/backups/restore`, {
+      body: { filename: 'backup.sql' },
+    });
+    expect(restore.status).toBe(200);
+    expect(restore.body.data.queued).toBe(true);
+
     expect(
-      (await http.post(`${path}/backups/restore`, { body: { filename: 'backup.sql' } })).status,
-    ).toBe(200);
+      (
+        await http.get(`${path}/backups/download`, {
+          searchParams: { filename: 'missing.sql' },
+        })
+      ).status,
+    ).toBe(404);
     expect(
       (
         await http.get(`${path}/backups/download`, {
           searchParams: { filename: 'backup.sql' },
         })
       ).status,
-    ).toBe(404);
+    ).toBe(200);
     expect((await http.delete(backupPath)).status).toBe(200);
 
     expect((await http.get(`${path}/previews`)).status).toBe(200);

--- a/src/test/integration/api/services.integration.test.ts
+++ b/src/test/integration/api/services.integration.test.ts
@@ -115,11 +115,12 @@ describe('service API', () => {
       body: { frequency: '0 0 * * *', enabled: true, saveS3: false },
     });
     expect(backup.status).toBe(201);
+    expect(backup.body.data.dumpAll).toBe(true);
     const backupPath = `${path}/backups/${backup.body.data.id as string}`;
     expect(
       (
         await http.patch(backupPath, {
-          body: { frequency: '0 1 * * *', enabled: true, saveS3: false },
+          body: { frequency: '0 1 * * *', enabled: true, saveS3: false, dumpAll: false },
         })
       ).status,
     ).toBe(200);
@@ -128,6 +129,13 @@ describe('service API', () => {
     expect(
       (await http.post(`${path}/backups/restore`, { body: { filename: 'backup.sql' } })).status,
     ).toBe(200);
+    expect(
+      (
+        await http.get(`${path}/backups/download`, {
+          searchParams: { filename: 'backup.sql' },
+        })
+      ).status,
+    ).toBe(404);
     expect((await http.delete(backupPath)).status).toBe(200);
 
     expect((await http.get(`${path}/previews`)).status).toBe(200);

--- a/worker/handlers/backup.ts
+++ b/worker/handlers/backup.ts
@@ -1,7 +1,34 @@
 import { registerHandler } from './index';
-import { runBackup } from '../../src/services/internal/backup/engine';
+import { runBackup, runRestore } from '../../src/services/internal/backup/engine';
+import { notifyService } from '../../src/services/internal/notifications/events';
+import { prisma } from '../../src/lib/prisma';
 
 registerHandler('backup.run', async (msg, ctx) => {
   ctx.log(`Running backup ${msg.backupId}`);
   await runBackup(msg.backupId, msg.executionId);
+});
+
+registerHandler('backup.restore', async (msg, ctx) => {
+  ctx.log(`Restoring ${msg.filename} onto service ${msg.serviceId}`);
+  const svc = await prisma.service.findUnique({
+    where: { id: msg.serviceId },
+    select: { id: true, name: true },
+  });
+  try {
+    await runRestore(msg.serviceId, msg.filename);
+    if (svc) {
+      await notifyService(svc.id, 'backup_success', {
+        subject: `Restore succeeded: ${svc.name}`,
+        text: `Database restore for "${svc.name}" from ${msg.filename} completed.`,
+      });
+    }
+  } catch (err) {
+    if (svc) {
+      await notifyService(svc.id, 'backup_failure', {
+        subject: `Restore failed: ${svc.name}`,
+        text: `Database restore for "${svc.name}" from ${msg.filename} failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+    throw err;
+  }
 });

--- a/worker/scheduler.ts
+++ b/worker/scheduler.ts
@@ -45,7 +45,7 @@ async function tick(log: Log) {
   for (const backup of backups) {
     if (!shouldFire(`backup:${backup.id}`, backup.frequency, now)) continue;
     const execution = await prisma.scheduledBackupExecution.create({
-      data: { backupId: backup.id, status: 'RUNNING' },
+      data: { backupId: backup.id, status: 'RUNNING', dumpAll: backup.dumpAll },
     });
     await enqueue({ type: 'backup.run', backupId: backup.id, executionId: execution.id });
     log(`enqueued backup.run for backup ${backup.id}`);


### PR DESCRIPTION
## Summary
- Default DB backup schedules to entire-instance dumps (`pg_dumpall` / `--all-databases`), with optional single-DB mode, paginated previous backups, and download support
- Queue restores via `backup.restore` on the tasks worker instead of running them inline in the API
- Format scheduled-task execution output (pretty JSON when possible; clearer cards otherwise)
- Fix rollback so deploy checks out the target deployment’s commit SHA instead of rebuilding from branch tip

## Test plan
- [ ] Create a DB backup schedule and confirm it defaults to entire instance; toggle to single DB and save
- [ ] Run backup now; verify previous backups list shows 5 with Load more; download a successful dump
- [ ] Queue a restore and confirm worker applies it asynchronously (toast says queued)
- [ ] Expand a scheduled task’s executions and confirm JSON output is pretty-printed
- [ ] Rollback a previous git deploy and confirm logs show checkout of that commit (not latest branch tip)
- [ ] Apply migration `20260724183000_backup_dump_all_default` on the target environment


Made with [Cursor](https://cursor.com)