### PR TITLE
warn: stop service before delete — containers keep running

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,7 @@ jobs:
       - uses: actions/checkout@v7
       # npm retired legacy /security/audits endpoints; pnpm 10.x audit is broken.
       # Use pnpm 11 for audit only (packageManager still pins 10.8.0 for installs).
-      - uses: pnpm/action-setup@v6
-        with:
-          version: 11.17.0
-      - uses: actions/setup-node@v7
-        with:
-          node-version: '22'
-      # Prevent pnpm 11 from switching back to packageManager (10.8.0).
+      # Unpin before pnpm/action-setup so it does not conflict with packageManager.
       - name: Unpin packageManager for audit
         run: |
           node <<'EOF'
@@ -48,6 +42,12 @@ jobs:
           delete pkg.packageManager
           fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n')
           EOF
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11.17.0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
       # Free npm advisory DB — fail on high/critical production vulns.
       # Lockfile alone is enough; no install required.
       - run: pnpm audit --prod --audit-level=high

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,15 +31,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      # npm retired legacy /security/audits endpoints; pnpm 10.x audit is broken.
+      # Use pnpm 11 for audit only (packageManager still pins 10.8.0 for installs).
       - uses: pnpm/action-setup@v6
         with:
-          version: 10.8.0
+          version: 11.17.0
       - uses: actions/setup-node@v7
         with:
           node-version: '22'
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      # Prevent pnpm 11 from switching back to packageManager (10.8.0).
+      - name: Unpin packageManager for audit
+        run: |
+          node <<'EOF'
+          const fs = require('fs')
+          const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'))
+          delete pkg.packageManager
+          fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n')
+          EOF
       # Free npm advisory DB — fail on high/critical production vulns.
+      # Lockfile alone is enough; no install required.
       - run: pnpm audit --prod --audit-level=high
 
   unit:

--- a/src/app/(app)/projects/[projectId]/services/[serviceId]/page.tsx
+++ b/src/app/(app)/projects/[projectId]/services/[serviceId]/page.tsx
@@ -19,6 +19,7 @@ import {
   Download,
   RefreshCw,
   CircleHelp,
+  TriangleAlert,
 } from 'lucide-react';
 import { type ServiceSectionId as SectionId } from '@/lib/service-sections';
 import {
@@ -98,6 +99,7 @@ import {
 } from '@/services/api/deployment';
 import { PageContainer, Panel } from '@/components/app/page';
 import { ConfirmButton } from '@/components/app/confirm';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { StatusBadge } from '@/components/app/status-badge';
 import { RunOutput } from '@/components/app/run-output';
 import { KindChip } from '@/components/app/kind-chip';
@@ -3523,7 +3525,18 @@ function DangerTab({
         <ConfirmButton
           onConfirm={() => delMut.mutate()}
           title={`Delete service "${name}"?`}
-          description="This permanently deletes the service, its configuration, environment variables, and deployment history."
+          description={
+            <div className="space-y-3">
+              <p>
+                This permanently deletes the service, its configuration, environment variables, and
+                deployment history from Peon.
+              </p>
+              <p className="text-amber-700 dark:text-amber-400 font-medium">
+                Stop the service first. Deleting does not stop or remove containers on the server —
+                they will keep running until you stop the service (or clean them up manually).
+              </p>
+            </div>
+          }
           confirmLabel="Delete permanently"
           size="sm"
           disabled={confirm !== name || delMut.isPending}
@@ -3532,10 +3545,18 @@ function DangerTab({
         </ConfirmButton>
       }
     >
-        <p className="text-muted-foreground text-sm">
-          This permanently deletes the service and its configuration. Type <b>{name}</b> to confirm.
-        </p>
-        <Input value={confirm} onChange={(e) => setConfirm(e.target.value)} placeholder={name} />
+      <Alert className="border-amber-500/40 bg-amber-500/10 text-amber-950 dark:text-amber-50">
+        <TriangleAlert />
+        <AlertTitle>Stop the service first</AlertTitle>
+        <AlertDescription className="text-amber-900/85 dark:text-amber-100/80">
+          Deleting a service removes it from Peon only. Running containers on the server are not
+          stopped. Stop the service before deleting it.
+        </AlertDescription>
+      </Alert>
+      <p className="text-muted-foreground text-sm">
+        This permanently deletes the service and its configuration. Type <b>{name}</b> to confirm.
+      </p>
+      <Input value={confirm} onChange={(e) => setConfirm(e.target.value)} placeholder={name} />
     </Panel>
   );
 }

--- a/src/lib/mcp/tools/services.ts
+++ b/src/lib/mcp/tools/services.ts
@@ -79,7 +79,7 @@ export function registerServiceTools(server: McpServer, ctx: McpContext, access:
 
   server.tool(
     'delete_service',
-    'Delete a service. Requires manage access.',
+    'Delete a service from Peon. Does not stop or remove containers on the server — stop the service first. Requires manage access.',
     { serviceId: z.string().describe('The service ID') },
     safe(async ({ serviceId }) => {
       await serviceAccess(serviceId, true);


### PR DESCRIPTION
## Summary
- Deleting a service currently removes Peon records only and does **not** stop containers on the host.
- Add a clear warning on the service Danger tab (and in the confirm dialog) to **stop the service first** before deleting.
- Update the MCP `delete_service` tool description with the same guidance.

## Test plan
- [ ] Open a service → Danger tab — see amber “Stop the service first” alert
- [ ] Type the service name and open Delete permanently — confirm dialog repeats the stop-first warning
- [ ] Delete still works after confirmation (behavior unchanged; warning only)

Made with [Cursor](https://cursor.com)