### PR TITLE
Fix/auth rate limiting

### DIFF
--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -42,7 +42,7 @@ Ask Chat questions like “How do I add a domain?” Chat calls `lookup_user_man
 
 **Who:** anyone with registration enabled (or an invite).
 
-**Common errors:** Registration disabled → ask a workspace OWNER/ADMIN or the person who runs your Peon installation. Google button missing → Google sign-in is not enabled for this installation.
+**Common errors:** Registration disabled → ask a workspace OWNER/ADMIN or the person who runs your Peon installation. Google button missing → Google sign-in is not enabled for this installation. Too many attempts / HTTP 429 → wait a minute and try again; public auth endpoints are rate limited.
 
 ### Accept an invitation
 

--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -1,10 +1,12 @@
 import type { NextRequest } from 'next/server';
 import { ok, route } from '@/lib/http/response';
 import { AuthService } from '@/services/internal/auth/auth';
+import { assertAuthRateLimit } from '@/lib/auth/auth-rate-limit';
 import { forgotPasswordSchema } from '@/schemas/auth.schema';
 
 export const POST = route(async (request: NextRequest) => {
   const body = forgotPasswordSchema.parse(await request.json());
+  assertAuthRateLimit('forgot-password', request.headers, body.email);
   await AuthService.forgotPassword(body.email);
   return ok({ message: 'If an account exists, a reset code has been sent.' });
 });

--- a/src/app/api/auth/google/verify/route.ts
+++ b/src/app/api/auth/google/verify/route.ts
@@ -3,10 +3,12 @@ import { ok, route } from '@/lib/http/response';
 import { AuthService } from '@/services/internal/auth/auth';
 import { setAuthCookie } from '@/lib/auth/cookies';
 import { extractSessionMeta } from '@/lib/auth/session-meta';
+import { assertAuthRateLimit } from '@/lib/auth/auth-rate-limit';
 import { googleVerifySchema } from '@/schemas/auth.schema';
 
 export const POST = route(async (request: NextRequest) => {
   const body = googleVerifySchema.parse(await request.json());
+  assertAuthRateLimit('google', request.headers);
   const meta = extractSessionMeta(request.headers);
   const result = await AuthService.loginWithGoogle(body.accessToken, meta);
   await setAuthCookie(result.token);

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -3,10 +3,12 @@ import { ok, route } from '@/lib/http/response';
 import { AuthService } from '@/services/internal/auth/auth';
 import { setAuthCookie } from '@/lib/auth/cookies';
 import { extractSessionMeta } from '@/lib/auth/session-meta';
+import { assertAuthRateLimit } from '@/lib/auth/auth-rate-limit';
 import { loginSchema } from '@/schemas/auth.schema';
 
 export const POST = route(async (request: NextRequest) => {
   const body = loginSchema.parse(await request.json());
+  assertAuthRateLimit('login', request.headers, body.email);
   const meta = extractSessionMeta(request.headers);
   const result = await AuthService.login(body.email, body.password, meta);
   await setAuthCookie(result.token);

--- a/src/app/api/auth/resend-otp/route.ts
+++ b/src/app/api/auth/resend-otp/route.ts
@@ -1,10 +1,12 @@
 import type { NextRequest } from 'next/server';
 import { ok, route } from '@/lib/http/response';
 import { AuthService } from '@/services/internal/auth/auth';
+import { assertAuthRateLimit } from '@/lib/auth/auth-rate-limit';
 import { resendOtpSchema } from '@/schemas/auth.schema';
 
 export const POST = route(async (request: NextRequest) => {
   const body = resendOtpSchema.parse(await request.json());
+  assertAuthRateLimit('resend-otp', request.headers, body.email);
   await AuthService.resendOtp(body.email, body.purpose);
   return ok({ message: 'Verification code resent.' });
 });

--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -1,10 +1,12 @@
 import type { NextRequest } from 'next/server';
 import { ok, route } from '@/lib/http/response';
 import { AuthService } from '@/services/internal/auth/auth';
+import { assertAuthRateLimit } from '@/lib/auth/auth-rate-limit';
 import { resetPasswordSchema } from '@/schemas/auth.schema';
 
 export const POST = route(async (request: NextRequest) => {
   const body = resetPasswordSchema.parse(await request.json());
+  assertAuthRateLimit('reset-password', request.headers, body.email);
   await AuthService.resetPassword(body);
   return ok({ message: 'Password updated. You can now sign in.' });
 });

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -1,10 +1,12 @@
 import type { NextRequest } from 'next/server';
 import { ok, route } from '@/lib/http/response';
 import { AuthService } from '@/services/internal/auth/auth';
+import { assertAuthRateLimit } from '@/lib/auth/auth-rate-limit';
 import { signupInitiateSchema } from '@/schemas/auth.schema';
 
 export const POST = route(async (request: NextRequest) => {
   const body = signupInitiateSchema.parse(await request.json());
+  assertAuthRateLimit('signup', request.headers, body.email);
   await AuthService.initiateSignup(body.email);
   return ok({ message: 'Verification code sent to your email.' });
 });

--- a/src/app/api/auth/verify-signup/route.ts
+++ b/src/app/api/auth/verify-signup/route.ts
@@ -3,10 +3,12 @@ import { ok, route } from '@/lib/http/response';
 import { AuthService } from '@/services/internal/auth/auth';
 import { setAuthCookie } from '@/lib/auth/cookies';
 import { extractSessionMeta } from '@/lib/auth/session-meta';
+import { assertAuthRateLimit } from '@/lib/auth/auth-rate-limit';
 import { signupCompleteSchema } from '@/schemas/auth.schema';
 
 export const POST = route(async (request: NextRequest) => {
   const body = signupCompleteSchema.parse(await request.json());
+  assertAuthRateLimit('verify-signup', request.headers, body.email);
   const meta = extractSessionMeta(request.headers);
   const result = await AuthService.completeSignup(body, meta);
   await setAuthCookie(result.token);

--- a/src/lib/__tests__/rate-limit.test.ts
+++ b/src/lib/__tests__/rate-limit.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { assertRateLimit, clearRateLimitStore } from '../rate-limit';
+import { RateLimitError } from '@/lib/errors';
+
+describe('assertRateLimit', () => {
+  beforeEach(() => {
+    clearRateLimitStore();
+  });
+
+  it('allows requests under the limit', () => {
+    expect(() => assertRateLimit('t:a', 3, 60_000)).not.toThrow();
+    expect(() => assertRateLimit('t:a', 3, 60_000)).not.toThrow();
+    expect(() => assertRateLimit('t:a', 3, 60_000)).not.toThrow();
+  });
+
+  it('rejects when the limit is exceeded', () => {
+    assertRateLimit('t:b', 2, 60_000);
+    assertRateLimit('t:b', 2, 60_000);
+    expect(() => assertRateLimit('t:b', 2, 60_000)).toThrow(RateLimitError);
+  });
+
+  it('isolates keys from each other', () => {
+    assertRateLimit('t:c1', 1, 60_000);
+    expect(() => assertRateLimit('t:c1', 1, 60_000)).toThrow(RateLimitError);
+    expect(() => assertRateLimit('t:c2', 1, 60_000)).not.toThrow();
+  });
+});

--- a/src/lib/auth/__tests__/auth-rate-limit.test.ts
+++ b/src/lib/auth/__tests__/auth-rate-limit.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { assertAuthRateLimit } from '../auth-rate-limit';
+import { clearRateLimitStore } from '@/lib/rate-limit';
+import { RateLimitError } from '@/lib/errors';
+
+function headersWithIp(ip: string): Headers {
+  return new Headers({ 'x-forwarded-for': ip });
+}
+
+describe('assertAuthRateLimit', () => {
+  beforeEach(() => {
+    clearRateLimitStore();
+  });
+
+  it('rate limits login by email independently of ip', () => {
+    const email = 'user@peon.test';
+    for (let i = 0; i < 10; i += 1) {
+      assertAuthRateLimit('login', headersWithIp(`203.0.113.${i}`), email);
+    }
+    expect(() => assertAuthRateLimit('login', headersWithIp('203.0.113.99'), email)).toThrow(
+      RateLimitError,
+    );
+  });
+
+  it('rate limits login by ip independently of email', () => {
+    const ipHeaders = headersWithIp('198.51.100.10');
+    for (let i = 0; i < 20; i += 1) {
+      assertAuthRateLimit('login', ipHeaders, `user-${i}@peon.test`);
+    }
+    expect(() => assertAuthRateLimit('login', ipHeaders, 'other@peon.test')).toThrow(RateLimitError);
+  });
+});

--- a/src/lib/auth/__tests__/auth-rate-limit.test.ts
+++ b/src/lib/auth/__tests__/auth-rate-limit.test.ts
@@ -29,4 +29,20 @@ describe('assertAuthRateLimit', () => {
     }
     expect(() => assertAuthRateLimit('login', ipHeaders, 'other@peon.test')).toThrow(RateLimitError);
   });
+
+  it('skips the ip limit when no forwarded ip is present', () => {
+    const noIp = new Headers();
+    for (let i = 0; i < 25; i += 1) {
+      expect(() => assertAuthRateLimit('login', noIp, `user-${i}@peon.test`)).not.toThrow();
+    }
+  });
+
+  it('still rate limits by email when no forwarded ip is present', () => {
+    const noIp = new Headers();
+    const email = 'shared@peon.test';
+    for (let i = 0; i < 10; i += 1) {
+      assertAuthRateLimit('login', noIp, email);
+    }
+    expect(() => assertAuthRateLimit('login', noIp, email)).toThrow(RateLimitError);
+  });
 });

--- a/src/lib/auth/auth-rate-limit.ts
+++ b/src/lib/auth/auth-rate-limit.ts
@@ -1,0 +1,73 @@
+import { extractSessionMeta } from '@/lib/auth/session-meta';
+import { assertRateLimit } from '@/lib/rate-limit';
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+
+type AuthRateAction =
+  | 'login'
+  | 'signup'
+  | 'forgot-password'
+  | 'resend-otp'
+  | 'verify-signup'
+  | 'reset-password'
+  | 'google';
+
+const LIMITS: Record<
+  AuthRateAction,
+  { ip: { limit: number; windowMs: number }; email?: { limit: number; windowMs: number } }
+> = {
+  login: {
+    ip: { limit: 20, windowMs: MINUTE },
+    email: { limit: 10, windowMs: MINUTE },
+  },
+  signup: {
+    ip: { limit: 20, windowMs: HOUR },
+    email: { limit: 5, windowMs: HOUR },
+  },
+  'forgot-password': {
+    ip: { limit: 20, windowMs: HOUR },
+    email: { limit: 5, windowMs: HOUR },
+  },
+  'resend-otp': {
+    ip: { limit: 20, windowMs: HOUR },
+    email: { limit: 5, windowMs: HOUR },
+  },
+  'verify-signup': {
+    ip: { limit: 30, windowMs: MINUTE },
+    email: { limit: 15, windowMs: MINUTE },
+  },
+  'reset-password': {
+    ip: { limit: 30, windowMs: MINUTE },
+    email: { limit: 15, windowMs: MINUTE },
+  },
+  google: {
+    ip: { limit: 20, windowMs: MINUTE },
+  },
+};
+
+function clientIp(headers: Headers): string {
+  return extractSessionMeta(headers).ip ?? 'unknown';
+}
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export function assertAuthRateLimit(
+  action: AuthRateAction,
+  headers: Headers,
+  email?: string,
+): void {
+  const limits = LIMITS[action];
+  const ip = clientIp(headers);
+  assertRateLimit(`auth:${action}:ip:${ip}`, limits.ip.limit, limits.ip.windowMs);
+
+  if (limits.email && email) {
+    assertRateLimit(
+      `auth:${action}:email:${normalizeEmail(email)}`,
+      limits.email.limit,
+      limits.email.windowMs,
+    );
+  }
+}

--- a/src/lib/auth/auth-rate-limit.ts
+++ b/src/lib/auth/auth-rate-limit.ts
@@ -46,8 +46,8 @@ const LIMITS: Record<
   },
 };
 
-function clientIp(headers: Headers): string {
-  return extractSessionMeta(headers).ip ?? 'unknown';
+function clientIp(headers: Headers): string | null {
+  return extractSessionMeta(headers).ip;
 }
 
 function normalizeEmail(email: string): string {
@@ -61,7 +61,9 @@ export function assertAuthRateLimit(
 ): void {
   const limits = LIMITS[action];
   const ip = clientIp(headers);
-  assertRateLimit(`auth:${action}:ip:${ip}`, limits.ip.limit, limits.ip.windowMs);
+  if (ip) {
+    assertRateLimit(`auth:${action}:ip:${ip}`, limits.ip.limit, limits.ip.windowMs);
+  }
 
   if (limits.email && email) {
     assertRateLimit(

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -47,3 +47,9 @@ export class PaymentRequiredError extends AppError {
     super(message, 402, code);
   }
 }
+
+export class RateLimitError extends AppError {
+  constructor(message = 'Too many requests. Please try again later.') {
+    super(message, 429, 'RATE_LIMITED');
+  }
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -31,6 +31,8 @@ export function assertRateLimit(key: string, limit: number, windowMs: number): v
   const existing = buckets.get(key);
   const timestamps = prune(existing?.timestamps ?? [], windowStart);
 
+  buckets.delete(key);
+
   if (timestamps.length >= limit) {
     buckets.set(key, { timestamps });
     throw new RateLimitError();

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,46 @@
+import { RateLimitError } from '@/lib/errors';
+
+type Bucket = {
+  timestamps: number[];
+};
+
+const buckets = new Map<string, Bucket>();
+
+const MAX_KEYS = 10_000;
+
+function prune(timestamps: number[], windowStart: number): number[] {
+  let i = 0;
+  while (i < timestamps.length && timestamps[i]! < windowStart) i += 1;
+  return i === 0 ? timestamps : timestamps.slice(i);
+}
+
+function evictIfNeeded(): void {
+  if (buckets.size <= MAX_KEYS) return;
+  const excess = buckets.size - MAX_KEYS;
+  const keys = buckets.keys();
+  for (let i = 0; i < excess; i += 1) {
+    const next = keys.next();
+    if (next.done) break;
+    buckets.delete(next.value);
+  }
+}
+
+export function assertRateLimit(key: string, limit: number, windowMs: number): void {
+  const now = Date.now();
+  const windowStart = now - windowMs;
+  const existing = buckets.get(key);
+  const timestamps = prune(existing?.timestamps ?? [], windowStart);
+
+  if (timestamps.length >= limit) {
+    buckets.set(key, { timestamps });
+    throw new RateLimitError();
+  }
+
+  timestamps.push(now);
+  buckets.set(key, { timestamps });
+  evictIfNeeded();
+}
+
+export function clearRateLimitStore(): void {
+  buckets.clear();
+}

--- a/src/test/integration/setup.ts
+++ b/src/test/integration/setup.ts
@@ -2,8 +2,10 @@ import './env';
 import { beforeEach } from 'vitest';
 import { resetDatabase } from './db';
 import { clearCookies } from './http';
+import { clearRateLimitStore } from '@/lib/rate-limit';
 
 beforeEach(async () => {
   clearCookies();
+  clearRateLimitStore();
   await resetDatabase();
 });


### PR DESCRIPTION
This adds basic rate limiting on the public auth endpoints so login, signup, forgot password, resend OTP, verify signup, reset password, and Google verify can't be hammered forever.

It uses an in-memory sliding window keyed by IP and email. Once you hit the limit you get a 429 with RATE_LIMITED, and that happens before bcrypt or any email send.

I kept it in-memory on purpose because at this point spinning up redis doesn't add value to the idea of Peon. Since Peon is a single device or an extension of local compute, in-memory is the way to go for now as far as in-memory goes. We can also remove the sliding window logic and store IP addresses, so the service doesn't shut down temporarily, entirely for a period of time but this implementation fixes the most major High Level.