### PR TITLE
fix: edit S3 storages and keep backup S3 settings on partial save

### DIFF
--- a/src/app/(app)/storages/page.tsx
+++ b/src/app/(app)/storages/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { Plus, Database, Trash2 } from 'lucide-react';
+import { Plus, Database, Pencil, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import {
@@ -21,9 +21,12 @@ import { ConfirmButton } from '@/components/app/confirm';
 import { useAuthStore } from '@/store/auth';
 import {
   listStorages,
+  getStorage,
   createStorage,
+  updateStorage,
   deleteStorage,
   testStorage,
+  type Storage,
   type CreateStoragePayload,
 } from '@/services/api/storages';
 
@@ -41,7 +44,9 @@ export default function StoragesPage() {
   const wsId = currentWorkspaceId!;
   const qc = useQueryClient();
   const [open, setOpen] = useState(false);
-  const [form, setForm] = useState<CreateStoragePayload>(EMPTY);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [loadingStorageId, setLoadingStorageId] = useState<string | null>(null);
+  const [form, setForm] = useState<CreateStoragePayload>({ ...EMPTY });
 
   const { data: storages, isLoading } = useQuery({
     queryKey: ['storages', wsId],
@@ -51,14 +56,81 @@ export default function StoragesPage() {
 
   const invalidate = () => qc.invalidateQueries({ queryKey: ['storages', wsId] });
   const set = (k: keyof CreateStoragePayload, v: string) => setForm((f) => ({ ...f, [k]: v }));
+  const isEditing = editingId !== null;
+
+  const resetForm = () => {
+    setEditingId(null);
+    setLoadingStorageId(null);
+    setForm({ ...EMPTY });
+  };
+
+  const openCreate = () => {
+    resetForm();
+    setOpen(true);
+  };
+
+  const openEdit = async (storage: Storage) => {
+    setEditingId(storage.id);
+    setForm({
+      name: storage.name,
+      region: storage.region,
+      endpoint: storage.endpoint ?? '',
+      bucket: storage.bucket,
+      accessKey: '',
+      secretKey: '',
+    });
+    setOpen(true);
+    setLoadingStorageId(storage.id);
+
+    try {
+      const details = await getStorage(storage.id);
+      setForm({
+        name: details.name,
+        region: details.region,
+        endpoint: details.endpoint ?? '',
+        bucket: details.bucket,
+        accessKey: details.accessKey,
+        secretKey: '',
+      });
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to load storage');
+      setOpen(false);
+      resetForm();
+    } finally {
+      setLoadingStorageId((id) => (id === storage.id ? null : id));
+    }
+  };
 
   const createMut = useMutation({
     mutationFn: () => createStorage(wsId, form),
     onSuccess: async () => {
       await invalidate();
       setOpen(false);
-      setForm(EMPTY);
+      resetForm();
       toast.success('Storage created');
+    },
+    onError: (e) => toast.error(e instanceof Error ? e.message : 'Failed'),
+  });
+
+  const updateMut = useMutation({
+    mutationFn: () => {
+      if (!editingId) {
+        throw new Error('No storage selected');
+      }
+      return updateStorage(editingId, {
+        name: form.name,
+        region: form.region,
+        endpoint: form.endpoint || null,
+        bucket: form.bucket,
+        accessKey: form.accessKey,
+        ...(form.secretKey ? { secretKey: form.secretKey } : {}),
+      });
+    },
+    onSuccess: async () => {
+      await invalidate();
+      setOpen(false);
+      resetForm();
+      toast.success('Storage updated');
     },
     onError: (e) => toast.error(e instanceof Error ? e.message : 'Failed'),
   });
@@ -80,10 +152,16 @@ export default function StoragesPage() {
   });
 
   const createDialog = (
-    <Modal open={open} onOpenChange={setOpen}>
+    <Modal
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) resetForm();
+      }}
+    >
       <ModalContent>
         <ModalHeader>
-          <ModalTitle>Create S3 storage</ModalTitle>
+          <ModalTitle>{isEditing ? 'Edit S3 storage' : 'Create S3 storage'}</ModalTitle>
         </ModalHeader>
         <ModalBody className="space-y-4">
           {(
@@ -97,28 +175,43 @@ export default function StoragesPage() {
             ] as const
           ).map(([k, label]) => (
             <div key={k} className="space-y-2">
-              <Label htmlFor={`st-${k}`}>{label}</Label>
+              <Label htmlFor={`st-${k}`}>
+                {isEditing && k === 'secretKey' ? 'Secret key (replace)' : label}
+              </Label>
               <Input
                 id={`st-${k}`}
                 type={k === 'secretKey' ? 'password' : 'text'}
+                placeholder={
+                  isEditing && k === 'secretKey'
+                    ? 'Leave blank to keep the current secret key'
+                    : undefined
+                }
                 value={(form[k] as string) ?? ''}
                 onChange={(e) => set(k, e.target.value)}
+                disabled={isEditing && loadingStorageId === editingId && k === 'accessKey'}
               />
+              {isEditing && k === 'secretKey' ? (
+                <p className="text-[11px] text-muted-foreground">
+                  Leave this blank unless you want to replace the stored secret key.
+                </p>
+              ) : null}
             </div>
           ))}
         </ModalBody>
         <ModalFooter>
           <Button
-            onClick={() => createMut.mutate()}
+            onClick={() => (isEditing ? updateMut.mutate() : createMut.mutate())}
             disabled={
               !form.name ||
               !form.bucket ||
               !form.accessKey ||
-              !form.secretKey ||
-              createMut.isPending
+              (!isEditing && !form.secretKey) ||
+              createMut.isPending ||
+              updateMut.isPending ||
+              (isEditing && loadingStorageId === editingId)
             }
           >
-            Create
+            {isEditing ? 'Save changes' : 'Create'}
           </Button>
         </ModalFooter>
       </ModalContent>
@@ -141,7 +234,7 @@ export default function StoragesPage() {
           title="No storages yet"
           description="add an s3-compatible bucket to store backups and assets."
           action={
-            <Button onClick={() => setOpen(true)}>
+            <Button onClick={openCreate}>
               <Plus className="size-4" /> New storage
             </Button>
           }
@@ -167,6 +260,14 @@ export default function StoragesPage() {
                 <Button
                   size="sm"
                   variant="outline"
+                  onClick={() => openEdit(s)}
+                  disabled={loadingStorageId === s.id}
+                >
+                  <Pencil className="size-4" /> Edit
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
                   onClick={() => testMut.mutate(s.id)}
                   disabled={testMut.isPending}
                 >
@@ -187,7 +288,7 @@ export default function StoragesPage() {
           ))}
           <button
             type="button"
-            onClick={() => setOpen(true)}
+            onClick={openCreate}
             className="border-border-bright text-muted-foreground hover:text-phosphor hover:border-phosphor-dim grid min-h-40 place-items-center rounded-lg border border-dashed transition-colors"
           >
             <span className="flex flex-col items-center gap-2 text-[12.5px]">

--- a/src/app/api/services/[serviceId]/backups/[backupId]/route.ts
+++ b/src/app/api/services/[serviceId]/backups/[backupId]/route.ts
@@ -3,7 +3,7 @@ import { ok, route } from '@/lib/http/response';
 import { requireProjectDelete, requireProjectManage } from '@/lib/auth/access';
 import { ServiceModule } from '@/services/internal/service/service';
 import { BackupModule } from '@/services/internal/backup/module';
-import { upsertBackupSchema } from '@/schemas/service.schema';
+import { updateBackupSchema } from '@/schemas/service.schema';
 
 type Ctx = { params: Promise<{ serviceId: string; backupId: string }> };
 
@@ -11,7 +11,7 @@ export const PATCH = route(async (request: NextRequest, { params }: Ctx) => {
   const { serviceId, backupId } = await params;
   const projectId = await ServiceModule.projectIdFor(serviceId);
   await requireProjectManage(projectId);
-  const body = upsertBackupSchema.partial().parse(await request.json());
+  const body = updateBackupSchema.parse(await request.json());
   return ok(await BackupModule.update(serviceId, backupId, body));
 });
 

--- a/src/schemas/__tests__/backup.schema.test.ts
+++ b/src/schemas/__tests__/backup.schema.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { updateBackupSchema, upsertBackupSchema } from '../service.schema';
+
+describe('updateBackupSchema', () => {
+  it('does not apply create defaults for omitted fields on PATCH', () => {
+    // Regression: upsertBackupSchema.partial() still applied .default(false) for
+    // saveS3, so saving only dumpAll cleared Upload to S3.
+    expect(upsertBackupSchema.partial().parse({ dumpAll: false })).toEqual({
+      enabled: true,
+      saveS3: false,
+      retentionAmountLocal: 7,
+      dumpAll: false,
+    });
+
+    expect(updateBackupSchema.parse({ dumpAll: false })).toEqual({ dumpAll: false });
+  });
+
+  it('accepts an explicit saveS3 toggle', () => {
+    expect(updateBackupSchema.parse({ saveS3: true })).toEqual({ saveS3: true });
+    expect(updateBackupSchema.parse({ saveS3: false })).toEqual({ saveS3: false });
+  });
+});

--- a/src/schemas/service.schema.ts
+++ b/src/schemas/service.schema.ts
@@ -218,7 +218,22 @@ export const upsertBackupSchema = z.object({
   dumpAll: z.boolean().default(true),
 });
 
+/**
+ * PATCH body: all fields optional, no Zod defaults.
+ * `.partial()` on the create schema still applies `.default()` for omitted keys
+ * (e.g. saving only `dumpAll` would reset `saveS3` to false).
+ */
+export const updateBackupSchema = z.object({
+  frequency: z.string().min(1).optional(),
+  enabled: z.boolean().optional(),
+  saveS3: z.boolean().optional(),
+  s3StorageId: z.string().nullable().optional(),
+  retentionAmountLocal: z.number().int().min(0).max(1000).optional(),
+  dumpAll: z.boolean().optional(),
+});
+
 export type UpsertBackupInput = z.infer<typeof upsertBackupSchema>;
+export type UpdateBackupInput = z.infer<typeof updateBackupSchema>;
 
 export const execCommandSchema = z.object({
   command: z.string().min(1).max(4000),

--- a/src/services/api/storages.ts
+++ b/src/services/api/storages.ts
@@ -13,6 +13,10 @@ export interface Storage {
   createdAt: string;
 }
 
+export interface StorageDetails extends Storage {
+  accessKey: string;
+}
+
 export interface CreateStoragePayload {
   name: string;
   description?: string | null;
@@ -25,6 +29,10 @@ export interface CreateStoragePayload {
 
 export function listStorages(workspaceId: string) {
   return unwrap<Storage[]>(api.get(`/workspaces/${workspaceId}/storages`));
+}
+
+export function getStorage(storageId: string) {
+  return unwrap<StorageDetails>(api.get(`/storages/${storageId}`));
 }
 
 export function createStorage(workspaceId: string, input: CreateStoragePayload) {

--- a/src/services/internal/backup/module.ts
+++ b/src/services/internal/backup/module.ts
@@ -2,7 +2,7 @@ import { prisma } from '@/lib/prisma';
 import { engineSpec } from '@/lib/docker/databases';
 import { enqueue } from '@/lib/queue/sqs';
 import { NotFoundError, ValidationError } from '@/lib/errors';
-import type { UpsertBackupInput } from '@/schemas/service.schema';
+import type { UpdateBackupInput, UpsertBackupInput } from '@/schemas/service.schema';
 import { recordServiceAudit } from '@/services/internal/audit/service-audit';
 
 /**
@@ -57,7 +57,7 @@ export const BackupModule = {
     return backup;
   },
 
-  async update(serviceId: string, backupId: string, input: Partial<UpsertBackupInput>) {
+  async update(serviceId: string, backupId: string, input: UpdateBackupInput) {
     const backup = await prisma.scheduledBackup.findFirst({ where: { id: backupId, serviceId } });
     if (!backup) throw new NotFoundError('Backup schedule not found.');
     const updated = await prisma.scheduledBackup.update({

--- a/src/services/internal/storages/storages.ts
+++ b/src/services/internal/storages/storages.ts
@@ -1,5 +1,5 @@
 import { prisma } from '@/lib/prisma';
-import { encrypt } from '@/lib/crypto/encryption';
+import { decrypt, encrypt } from '@/lib/crypto/encryption';
 import { NotFoundError } from '@/lib/errors';
 import type { CreateStorageInput, UpdateStorageInput } from '@/schemas/storages.schema';
 import { AuditService } from '@/services/internal/audit/audit';
@@ -15,6 +15,11 @@ const listSelect = {
   bucket: true,
   isUsable: true,
   createdAt: true,
+} as const;
+
+const detailSelect = {
+  ...listSelect,
+  accessKey: true,
 } as const;
 
 export const StorageService = {
@@ -51,10 +56,13 @@ export const StorageService = {
   async get(storageId: string) {
     const storage = await prisma.s3Storage.findUnique({
       where: { id: storageId },
-      select: listSelect,
+      select: detailSelect,
     });
     if (!storage) throw new NotFoundError('Storage not found.');
-    return storage;
+    return {
+      ...storage,
+      accessKey: decrypt(storage.accessKey),
+    };
   },
 
   async getRaw(storageId: string) {

--- a/src/test/integration/api/services.integration.test.ts
+++ b/src/test/integration/api/services.integration.test.ts
@@ -117,6 +117,22 @@ describe('service API', () => {
     expect(backup.status).toBe(201);
     expect(backup.body.data.dumpAll).toBe(true);
     const backupPath = `${path}/backups/${backup.body.data.id as string}`;
+
+    // Enable S3, then patch only dumpAll — Zod defaults must not reset saveS3.
+    expect(
+      (
+        await http.patch(backupPath, {
+          body: { saveS3: true },
+        })
+      ).status,
+    ).toBe(200);
+    const dumpOnly = await http.patch(backupPath, {
+      body: { dumpAll: false },
+    });
+    expect(dumpOnly.status).toBe(200);
+    expect(dumpOnly.body.data.dumpAll).toBe(false);
+    expect(dumpOnly.body.data.saveS3).toBe(true);
+
     expect(
       (
         await http.patch(backupPath, {

--- a/src/test/integration/api/sources-storages.integration.test.ts
+++ b/src/test/integration/api/sources-storages.integration.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@/test/integration/fixtures';
 import { http } from '@/test/integration/http';
 import { prisma } from '@/lib/prisma';
+import { decrypt } from '@/lib/crypto/encryption';
 
 describe('sources, storage, and workspace settings APIs', () => {
   it('manages GitHub sources and uses mocked repository APIs', async () => {
@@ -95,8 +96,25 @@ describe('sources, storage, and workspace settings APIs', () => {
     expect(created.status).toBe(201);
     const storagePath = `/api/storages/${created.body.data.id as string}`;
 
-    expect((await http.get(storagePath)).status).toBe(200);
-    expect((await http.patch(storagePath, { body: { name: 'archive' } })).status).toBe(200);
+    const detail = await http.get(storagePath);
+    expect(detail.status).toBe(200);
+    expect(detail.body.data.accessKey).toBe('key');
+    expect(detail.body.data.secretKey).toBeUndefined();
+
+    expect(
+      (
+        await http.patch(storagePath, {
+          body: { name: 'archive', accessKey: 'key-2' },
+        })
+      ).status,
+    ).toBe(200);
+    const stored = await prisma.s3Storage.findUniqueOrThrow({
+      where: { id: created.body.data.id as string },
+      select: { accessKey: true, secretKey: true },
+    });
+    expect(decrypt(stored.accessKey)).toBe('key-2');
+    expect(decrypt(stored.secretKey)).toBe('secret');
+
     expect((await http.post(`${storagePath}/test`)).status).toBe(200);
     expect((await http.delete(storagePath)).status).toBe(200);
   });


### PR DESCRIPTION
## Summary
- Add storage edit UI so users can update S3 connection details and see the existing access key (secret key remains write-only unless replaced).
- Fix backup schedule PATCH so saving only `dumpAll` no longer resets `saveS3` via Zod create-schema defaults.
- Cover both behaviors with schema/unit and integration assertions.

## Test plan
- [ ] Open Storages → Edit an existing bucket → confirm access key is prefilled and secret key can be left blank to keep the current value
- [ ] Save storage edits (name/region/bucket/access key) and confirm they persist
- [ ] On a DB service Backups tab, enable Upload to S3, then toggle Entire instance and Save → Upload to S3 stays enabled
- [ ] `pnpm exec vitest run src/schemas/__tests__/backup.schema.test.ts`
- [ ] Integration: storage detail/update assertions in `sources-storages.integration.test.ts`; dumpAll-only PATCH keeps `saveS3` in `services.integration.test.ts`


Made with [Cursor](https://cursor.com)