### PR TITLE
fix: accept null attribution on OTP signup

### DIFF
--- a/src/schemas/__tests__/auth.schema.test.ts
+++ b/src/schemas/__tests__/auth.schema.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { signupCompleteSchema } from '@/schemas/auth.schema';
+
+const base = {
+  email: 'user@peon.test',
+  name: 'User',
+  password: 'Test1234!',
+  code: '123456',
+};
+
+describe('signupCompleteSchema attribution', () => {
+  it('accepts signup without attribution', () => {
+    expect(signupCompleteSchema.safeParse(base).success).toBe(true);
+  });
+
+  it('accepts attribution: null (no campaign data)', () => {
+    const result = signupCompleteSchema.safeParse({ ...base, attribution: null });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.attribution).toBeNull();
+    }
+  });
+
+  it('strips empty / null attribution fields', () => {
+    const result = signupCompleteSchema.safeParse({
+      ...base,
+      attribution: {
+        utmSource: 'ph',
+        utmMedium: '',
+        utmCampaign: null,
+        landingPath: '/register',
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.attribution).toMatchObject({
+        utmSource: 'ph',
+        landingPath: '/register',
+      });
+      expect(result.data.attribution?.utmMedium).toBeUndefined();
+      expect(result.data.attribution?.utmCampaign).toBeUndefined();
+    }
+  });
+
+  it('accepts a full attribution payload', () => {
+    const result = signupCompleteSchema.safeParse({
+      ...base,
+      attribution: {
+        utmSource: 'producthunt',
+        utmMedium: 'social',
+        capturedAt: '2026-08-01T00:00:00.000Z',
+        rawQuery: { utm_source: 'producthunt' },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/schemas/auth.schema.ts
+++ b/src/schemas/auth.schema.ts
@@ -1,6 +1,11 @@
 import { z } from 'zod';
 
-const attributionField = z.string().trim().min(1).max(200).optional();
+const attributionField = z
+  .string()
+  .trim()
+  .max(200)
+  .nullish()
+  .transform((v) => (v && v.length > 0 ? v : undefined));
 
 /** Optional first-touch campaign attribution (strict allowlist). */
 export const attributionSchema = z
@@ -16,12 +21,27 @@ export const attributionSchema = z
     msclkid: attributionField,
     campaign: attributionField,
     landingPath: attributionField,
-    landingUrl: z.string().trim().min(1).max(500).optional(),
-    referrer: z.string().trim().min(1).max(500).optional(),
-    capturedAt: z.string().trim().min(1).max(40).optional(),
-    rawQuery: z.record(z.string(), z.string().max(200)).optional(),
+    landingUrl: z
+      .string()
+      .trim()
+      .max(500)
+      .nullish()
+      .transform((v) => (v && v.length > 0 ? v : undefined)),
+    referrer: z
+      .string()
+      .trim()
+      .max(500)
+      .nullish()
+      .transform((v) => (v && v.length > 0 ? v : undefined)),
+    capturedAt: z
+      .string()
+      .trim()
+      .max(40)
+      .nullish()
+      .transform((v) => (v && v.length > 0 ? v : undefined)),
+    rawQuery: z.record(z.string(), z.string().max(200)).nullish(),
   })
-  .optional();
+  .nullish();
 
 export const signupInitiateSchema = z.object({
   email: z.string().email(),

--- a/src/services/api/auth.ts
+++ b/src/services/api/auth.ts
@@ -40,7 +40,16 @@ export function completeSignup(input: {
   code: string;
   attribution?: AttributionInput | null;
 }) {
-  return unwrap<{ user: SessionUser }>(api.post('/auth/verify-signup', input));
+  return unwrap<{ user: SessionUser }>(
+    api.post('/auth/verify-signup', {
+      email: input.email,
+      name: input.name,
+      password: input.password,
+      code: input.code,
+      // Omit null — Zod optional rejects null and returns 422.
+      attribution: input.attribution ?? undefined,
+    }),
+  );
 }
 
 export function login(email: string, password: string) {


### PR DESCRIPTION
## Summary
- Organic (no UTM) OTP signups posted `attribution: null`, which Zod treated as invalid and returned **422 Unprocessable Content**
- Accept `null` / empty attribution fields in the schema, and omit `null` from the client payload (same pattern as Google verify)

## Test plan
- [ ] Sign up with email OTP **without** any UTM params → succeeds (no 422)
- [ ] Sign up with `?utm_source=ph` → succeeds and writes `UserAttribution`
- [ ] `pnpm exec vitest run src/schemas/__tests__/auth.schema.test.ts`


Made with [Cursor](https://cursor.com)