### PR TITLE
fix: normalize attribution rawQuery null for TypeScript

### DIFF
--- a/src/schemas/__tests__/auth.schema.test.ts
+++ b/src/schemas/__tests__/auth.schema.test.ts
@@ -54,4 +54,15 @@ describe('signupCompleteSchema attribution', () => {
     });
     expect(result.success).toBe(true);
   });
+
+  it('normalizes rawQuery null to undefined', () => {
+    const result = signupCompleteSchema.safeParse({
+      ...base,
+      attribution: { utmSource: 'ph', rawQuery: null },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.attribution?.rawQuery).toBeUndefined();
+    }
+  });
 });

--- a/src/schemas/auth.schema.ts
+++ b/src/schemas/auth.schema.ts
@@ -39,7 +39,10 @@ export const attributionSchema = z
       .max(40)
       .nullish()
       .transform((v) => (v && v.length > 0 ? v : undefined)),
-    rawQuery: z.record(z.string(), z.string().max(200)).nullish(),
+    rawQuery: z
+      .record(z.string(), z.string().max(200))
+      .nullish()
+      .transform((v) => v ?? undefined),
   })
   .nullish();
 


### PR DESCRIPTION
## Summary
- CI `pnpm build` failed because `attribution.rawQuery` could be `null` after Zod parse, but `AttributionInput` only allows `undefined`
- Transform `rawQuery: null` → `undefined` so Google/OTP signup routes typecheck

## Test plan
- [x] `pnpm exec vitest run src/schemas/__tests__/auth.schema.test.ts`
- [ ] CI API integration tests / `next build` passes


Made with [Cursor](https://cursor.com)