### PR TITLE
fix: stop returning session JWT in auth API responses

### DIFF
--- a/src/app/api/auth/google/verify/route.ts
+++ b/src/app/api/auth/google/verify/route.ts
@@ -9,6 +9,7 @@ export const POST = route(async (request: NextRequest) => {
   const body = googleVerifySchema.parse(await request.json());
   const meta = extractSessionMeta(request.headers);
   const result = await AuthService.loginWithGoogle(body.accessToken, meta, body.attribution);
-  await setAuthCookie(result.token);
-  return ok(result);
+  const { token, ...data } = result;
+  await setAuthCookie(token);
+  return ok(data);
 });

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -9,6 +9,7 @@ export const POST = route(async (request: NextRequest) => {
   const body = loginSchema.parse(await request.json());
   const meta = extractSessionMeta(request.headers);
   const result = await AuthService.login(body.email, body.password, meta);
-  await setAuthCookie(result.token);
-  return ok(result);
+  const { token, ...data } = result;
+  await setAuthCookie(token);
+  return ok(data);
 });

--- a/src/app/api/auth/profile/avatar/confirm/route.ts
+++ b/src/app/api/auth/profile/avatar/confirm/route.ts
@@ -10,6 +10,7 @@ export const POST = route(async (request: NextRequest) => {
   const user = await requireUser();
   const body = avatarConfirmSchema.parse(await request.json());
   const result = await ProfileService.confirmAvatar(user, session.sid!, body.key);
-  await setAuthCookie(result.token);
-  return ok(result);
+  const { token, ...data } = result;
+  await setAuthCookie(token);
+  return ok(data);
 });

--- a/src/app/api/auth/profile/avatar/route.ts
+++ b/src/app/api/auth/profile/avatar/route.ts
@@ -7,6 +7,7 @@ export const DELETE = route(async () => {
   const session = await requireSession();
   const user = await requireUser();
   const result = await ProfileService.removeAvatar(user, session.sid!);
-  await setAuthCookie(result.token);
-  return ok(result);
+  const { token, ...data } = result;
+  await setAuthCookie(token);
+  return ok(data);
 });

--- a/src/app/api/auth/profile/password/route.ts
+++ b/src/app/api/auth/profile/password/route.ts
@@ -10,6 +10,7 @@ export const POST = route(async (request: NextRequest) => {
   const user = await requireUser();
   const body = changePasswordSchema.parse(await request.json());
   const result = await ProfileService.setPassword(user, session.sid!, body);
-  await setAuthCookie(result.token);
-  return ok(result);
+  const { token, ...data } = result;
+  await setAuthCookie(token);
+  return ok(data);
 });

--- a/src/app/api/auth/profile/route.ts
+++ b/src/app/api/auth/profile/route.ts
@@ -10,6 +10,7 @@ export const PATCH = route(async (request: NextRequest) => {
   const user = await requireUser();
   const body = updateProfileSchema.parse(await request.json());
   const result = await ProfileService.updateName(user, session.sid!, body.name);
-  await setAuthCookie(result.token);
-  return ok(result);
+  const { token, ...data } = result;
+  await setAuthCookie(token);
+  return ok(data);
 });

--- a/src/app/api/auth/verify-signup/route.ts
+++ b/src/app/api/auth/verify-signup/route.ts
@@ -9,6 +9,7 @@ export const POST = route(async (request: NextRequest) => {
   const body = signupCompleteSchema.parse(await request.json());
   const meta = extractSessionMeta(request.headers);
   const result = await AuthService.completeSignup(body, meta);
-  await setAuthCookie(result.token);
-  return ok(result);
+  const { token, ...data } = result;
+  await setAuthCookie(token);
+  return ok(data);
 });


### PR DESCRIPTION
## Summary
- Strip `token` from JSON responses on login, signup verify, Google verify, and profile update routes after setting the httpOnly auth cookie
- Keep the existing response envelope (`success` / `data`) and all non-token fields (e.g. `user`) unchanged
- Reduces JWT exposure in Network tab / XSS exfiltration while session auth continues via cookie