### PR TITLE
fix: stop SQS from double-running long deployments

### DIFF
--- a/prisma/migrations/20260815154500_deployment_lease/migration.sql
+++ b/prisma/migrations/20260815154500_deployment_lease/migration.sql
@@ -1,0 +1,4 @@
+-- Single-flight lease so a redelivered SQS deploy job cannot run in parallel
+-- with the worker that still holds the original message.
+ALTER TABLE "Deployment" ADD COLUMN IF NOT EXISTS "leaseOwner" TEXT;
+ALTER TABLE "Deployment" ADD COLUMN IF NOT EXISTS "leaseUntil" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -812,6 +812,10 @@ model Deployment {
   startedAt   DateTime?
   finishedAt  DateTime?
   createdAt   DateTime         @default(now())
+  /// Worker that currently holds the in-progress lease (SQS redelivery guard).
+  leaseOwner  String?
+  /// Lease expiry; another worker may take over only after this instant.
+  leaseUntil  DateTime?
 
   service Service @relation(fields: [serviceId], references: [id], onDelete: Cascade)
 

--- a/src/lib/queue/__tests__/visibility-heartbeat.test.ts
+++ b/src/lib/queue/__tests__/visibility-heartbeat.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { startIntervalHeartbeat } from '../visibility-heartbeat';
+
+describe('startIntervalHeartbeat', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('ticks on the interval and stops after stop()', async () => {
+    vi.useFakeTimers();
+    const tick = vi.fn().mockResolvedValue(undefined);
+    const hb = startIntervalHeartbeat(tick, 1000);
+
+    expect(tick).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(tick).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(tick).toHaveBeenCalledTimes(3);
+
+    hb.stop();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(tick).toHaveBeenCalledTimes(3);
+  });
+
+  it('logs tick failures without throwing', async () => {
+    vi.useFakeTimers();
+    const tick = vi.fn().mockRejectedValue(new Error('ReceiptHandle is invalid'));
+    const log = vi.fn();
+    const hb = startIntervalHeartbeat(tick, 1000, { log });
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(log).toHaveBeenCalledWith('heartbeat failed: ReceiptHandle is invalid');
+    hb.stop();
+  });
+
+  it('stops after the first error when stopOnError is set', async () => {
+    vi.useFakeTimers();
+    const tick = vi.fn().mockRejectedValue(new Error('lease lost'));
+    const hb = startIntervalHeartbeat(tick, 1000, { stopOnError: true });
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(tick).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(tick).toHaveBeenCalledTimes(1);
+    hb.stop();
+  });
+});

--- a/src/lib/queue/sqs.ts
+++ b/src/lib/queue/sqs.ts
@@ -3,12 +3,20 @@ import {
   SendMessageCommand,
   ReceiveMessageCommand,
   DeleteMessageCommand,
+  ChangeMessageVisibilityCommand,
   type Message,
 } from '@aws-sdk/client-sqs';
 import { serverEnv } from '@/lib/env';
 import { isE2eMode } from '@/lib/e2e';
 import { awsCredentialsIfConfigured, awsRegion } from '@/lib/aws/credentials';
 import { type QueueMessage, type QueueName, queueForMessage } from './messages';
+import { startIntervalHeartbeat } from './visibility-heartbeat';
+
+/** Time a received message stays invisible before SQS redelivers it. */
+export const SQS_VISIBILITY_TIMEOUT_SECONDS = 900;
+
+/** Refresh visibility well before expiry so long builds are not redelivered. */
+export const SQS_VISIBILITY_HEARTBEAT_MS = 60_000;
 
 let client: SQSClient | null = null;
 
@@ -53,7 +61,7 @@ export async function receiveMessages(
       QueueUrl: queueUrl(name),
       WaitTimeSeconds: waitSeconds,
       MaxNumberOfMessages: max,
-      VisibilityTimeout: 900,
+      VisibilityTimeout: SQS_VISIBILITY_TIMEOUT_SECONDS,
     }),
   );
   return res.Messages ?? [];
@@ -63,4 +71,42 @@ export async function deleteMessage(name: QueueName, receiptHandle: string): Pro
   await getClient().send(
     new DeleteMessageCommand({ QueueUrl: queueUrl(name), ReceiptHandle: receiptHandle }),
   );
+}
+
+export async function extendMessageVisibility(
+  name: QueueName,
+  receiptHandle: string,
+  timeoutSeconds = SQS_VISIBILITY_TIMEOUT_SECONDS,
+): Promise<void> {
+  if (isE2eMode()) return;
+  await getClient().send(
+    new ChangeMessageVisibilityCommand({
+      QueueUrl: queueUrl(name),
+      ReceiptHandle: receiptHandle,
+      VisibilityTimeout: timeoutSeconds,
+    }),
+  );
+}
+
+/**
+ * Keep an in-flight SQS message hidden until `fn` returns.
+ * Without this, jobs longer than {@link SQS_VISIBILITY_TIMEOUT_SECONDS} are
+ * redelivered and a second worker starts the same deployment.
+ */
+export async function withVisibilityHeartbeat<T>(
+  name: QueueName,
+  receiptHandle: string,
+  fn: () => Promise<T>,
+  log?: (message: string) => void,
+): Promise<T> {
+  const heartbeat = startIntervalHeartbeat(
+    () => extendMessageVisibility(name, receiptHandle),
+    SQS_VISIBILITY_HEARTBEAT_MS,
+    { log },
+  );
+  try {
+    return await fn();
+  } finally {
+    heartbeat.stop();
+  }
 }

--- a/src/lib/queue/visibility-heartbeat.ts
+++ b/src/lib/queue/visibility-heartbeat.ts
@@ -1,0 +1,29 @@
+export type IntervalHeartbeatOptions = {
+  log?: (message: string) => void;
+  /** When true, the first rejected tick clears the interval (lost lease, invalid receipt). */
+  stopOnError?: boolean;
+};
+
+/**
+ * Periodic callback used to extend SQS visibility (or any similar lease)
+ * while a long-running job is in flight.
+ */
+export function startIntervalHeartbeat(
+  tick: () => Promise<void>,
+  intervalMs: number,
+  options: IntervalHeartbeatOptions = {},
+): { stop: () => void } {
+  let stopped = false;
+  const stop = () => {
+    stopped = true;
+    clearInterval(id);
+  };
+  const id = setInterval(() => {
+    if (stopped) return;
+    void tick().catch((err) => {
+      options.log?.(`heartbeat failed: ${err instanceof Error ? err.message : String(err)}`);
+      if (options.stopOnError) stop();
+    });
+  }, intervalMs);
+  return { stop };
+}

--- a/src/services/internal/deploy/__tests__/lease.test.ts
+++ b/src/services/internal/deploy/__tests__/lease.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    deployment: { updateMany: vi.fn() },
+  },
+}));
+
+import { prisma } from '@/lib/prisma';
+import {
+  isDeployLeaseExpired,
+  releaseDeployLease,
+  renewDeployLease,
+  tryAcquireDeployLease,
+} from '../lease';
+
+const updateMany = vi.mocked(prisma.deployment.updateMany);
+
+describe('isDeployLeaseExpired', () => {
+  const now = new Date('2026-08-15T12:00:00.000Z');
+
+  it('treats a missing lease as expired so the first worker can claim', () => {
+    expect(isDeployLeaseExpired(null, now)).toBe(true);
+    expect(isDeployLeaseExpired(undefined, now)).toBe(true);
+  });
+
+  it('treats a future lease as held', () => {
+    expect(isDeployLeaseExpired(new Date('2026-08-15T12:01:00.000Z'), now)).toBe(false);
+  });
+
+  it('treats a past lease as take-overable after a worker crash', () => {
+    expect(isDeployLeaseExpired(new Date('2026-08-15T11:59:00.000Z'), now)).toBe(true);
+  });
+});
+
+describe('tryAcquireDeployLease', () => {
+  beforeEach(() => {
+    updateMany.mockReset();
+  });
+
+  it('claims when no other worker holds a live lease', async () => {
+    updateMany.mockResolvedValue({ count: 1 });
+    const now = new Date('2026-08-15T12:00:00.000Z');
+    await expect(tryAcquireDeployLease('dep1', 'worker-a', now, 120_000)).resolves.toBe(true);
+    expect(updateMany).toHaveBeenCalledWith({
+      where: {
+        id: 'dep1',
+        status: 'IN_PROGRESS',
+        OR: [{ leaseUntil: null }, { leaseUntil: { lt: now } }],
+      },
+      data: { leaseOwner: 'worker-a', leaseUntil: new Date('2026-08-15T12:02:00.000Z') },
+    });
+  });
+
+  it('loses when another worker already holds the lease', async () => {
+    updateMany.mockResolvedValue({ count: 0 });
+    await expect(tryAcquireDeployLease('dep1', 'worker-b')).resolves.toBe(false);
+  });
+});
+
+describe('renewDeployLease', () => {
+  beforeEach(() => {
+    updateMany.mockReset();
+  });
+
+  it('renews only the owner of an in-progress deploy', async () => {
+    updateMany.mockResolvedValue({ count: 1 });
+    const now = new Date('2026-08-15T12:00:00.000Z');
+    await expect(renewDeployLease('dep1', 'worker-a', now, 120_000)).resolves.toBe(true);
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { id: 'dep1', leaseOwner: 'worker-a', status: 'IN_PROGRESS' },
+      data: { leaseUntil: new Date('2026-08-15T12:02:00.000Z') },
+    });
+  });
+
+  it('returns false after cancel or takeover', async () => {
+    updateMany.mockResolvedValue({ count: 0 });
+    await expect(renewDeployLease('dep1', 'worker-a')).resolves.toBe(false);
+  });
+});
+
+describe('releaseDeployLease', () => {
+  beforeEach(() => {
+    updateMany.mockReset();
+  });
+
+  it('clears the lease only for the owning worker', async () => {
+    updateMany.mockResolvedValue({ count: 1 });
+    await releaseDeployLease('dep1', 'worker-a');
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { id: 'dep1', leaseOwner: 'worker-a' },
+      data: { leaseOwner: null, leaseUntil: null },
+    });
+  });
+});

--- a/src/services/internal/deploy/engine.ts
+++ b/src/services/internal/deploy/engine.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { prisma } from '@/lib/prisma';
 import { NotFoundError } from '@/lib/errors';
 import { sshPool, sshTargetForServer, type SshTarget } from '@/lib/ssh';
@@ -47,6 +48,11 @@ import {
   statusAfterFailedDeploy,
 } from '@/services/internal/deploy/status';
 import { promoteServerAfterSlotFreed } from '@/services/internal/deploy/server-queue';
+import {
+  releaseDeployLease,
+  startDeployLeaseHeartbeat,
+  tryAcquireDeployLease,
+} from '@/services/internal/deploy/lease';
 import { notifyPreviewDeployOutcome } from '@/services/internal/deploy/preview';
 import {
   buildEnvMap,
@@ -451,28 +457,41 @@ export async function runDeployment(deploymentId: string): Promise<void> {
     return;
   }
 
+  // SQS redelivers after VisibilityTimeout unless the worker heartbeats.
+  // A second worker must not run the same IN_PROGRESS row in parallel.
+  const leaseOwner = randomUUID();
+  if (!(await tryAcquireDeployLease(deploymentId, leaseOwner))) {
+    await logger.info('Another worker is already running this deployment; skipping duplicate.');
+    return;
+  }
+  const leaseHeartbeat = startDeployLeaseHeartbeat(deploymentId, leaseOwner, (m) => {
+    void logger.info(m);
+  });
+
   const isPreview = deployment.isPreview && deployment.pullRequestId != null;
-  const preview = isPreview
-    ? await prisma.servicePreview.findUnique({
+  let preview: Awaited<ReturnType<typeof prisma.servicePreview.findUnique>> = null;
+
+  try {
+    if (isPreview) {
+      preview = await prisma.servicePreview.findUnique({
         where: {
           serviceId_pullRequestId: {
             serviceId: svc.id,
             pullRequestId: deployment.pullRequestId!,
           },
         },
-      })
-    : null;
+      });
+    }
 
-  if (!isPreview) {
-    await prisma.service.update({ where: { id: svc.id }, data: { status: 'STARTING' } });
-  } else if (preview) {
-    await prisma.servicePreview.update({
-      where: { id: preview.id },
-      data: { status: 'STARTING' },
-    });
-  }
+    if (!isPreview) {
+      await prisma.service.update({ where: { id: svc.id }, data: { status: 'STARTING' } });
+    } else if (preview) {
+      await prisma.servicePreview.update({
+        where: { id: preview.id },
+        data: { status: 'STARTING' },
+      });
+    }
 
-  try {
     await assertNotCancelled(deploymentId);
 
     const target = await sshTargetForServer(svc.serverId);
@@ -803,7 +822,17 @@ export async function runDeployment(deploymentId: string): Promise<void> {
       where: { id: deploymentId, status: 'IN_PROGRESS' },
       data: { status: 'FINISHED', finishedAt: new Date() },
     });
-    if (finished.count === 0) throw new DeploymentCancelledError();
+    if (finished.count === 0) {
+      const row = await prisma.deployment.findUnique({
+        where: { id: deploymentId },
+        select: { status: true },
+      });
+      if (row?.status === 'CANCELLED') throw new DeploymentCancelledError();
+      await logger.info(
+        `Not marking finished; deployment is already ${row?.status ?? 'missing'}.`,
+      );
+      return;
+    }
 
     if (isPreview && deployment.pullRequestId != null) {
       try {
@@ -915,6 +944,8 @@ export async function runDeployment(deploymentId: string): Promise<void> {
     }
     throw err;
   } finally {
+    leaseHeartbeat.stop();
+    await releaseDeployLease(deploymentId, leaseOwner);
     await promoteServerAfterSlotFreed(svc.serverId);
   }
 }

--- a/src/services/internal/deploy/lease.ts
+++ b/src/services/internal/deploy/lease.ts
@@ -1,0 +1,71 @@
+import { prisma } from '@/lib/prisma';
+import { startIntervalHeartbeat } from '@/lib/queue/visibility-heartbeat';
+
+/** How long a worker holds exclusive rights to run a deployment. */
+export const DEPLOY_LEASE_MS = 120_000;
+
+/** Renew well before expiry so a brief DB hiccup does not drop the lease. */
+export const DEPLOY_LEASE_RENEW_MS = 30_000;
+
+export function isDeployLeaseExpired(leaseUntil: Date | null | undefined, now: Date): boolean {
+  return leaseUntil == null || leaseUntil.getTime() < now.getTime();
+}
+
+/**
+ * Claim exclusive execution of an IN_PROGRESS deployment.
+ * Succeeds when no lease is held, or the previous worker's lease has expired
+ * (crash / lost SQS heartbeat). Concurrent claimants: at most one wins.
+ */
+export async function tryAcquireDeployLease(
+  deploymentId: string,
+  owner: string,
+  now = new Date(),
+  leaseMs = DEPLOY_LEASE_MS,
+): Promise<boolean> {
+  const updated = await prisma.deployment.updateMany({
+    where: {
+      id: deploymentId,
+      status: 'IN_PROGRESS',
+      OR: [{ leaseUntil: null }, { leaseUntil: { lt: now } }],
+    },
+    data: { leaseOwner: owner, leaseUntil: new Date(now.getTime() + leaseMs) },
+  });
+  return updated.count === 1;
+}
+
+export async function renewDeployLease(
+  deploymentId: string,
+  owner: string,
+  now = new Date(),
+  leaseMs = DEPLOY_LEASE_MS,
+): Promise<boolean> {
+  const updated = await prisma.deployment.updateMany({
+    where: { id: deploymentId, leaseOwner: owner, status: 'IN_PROGRESS' },
+    data: { leaseUntil: new Date(now.getTime() + leaseMs) },
+  });
+  return updated.count === 1;
+}
+
+export async function releaseDeployLease(deploymentId: string, owner: string): Promise<void> {
+  await prisma.deployment.updateMany({
+    where: { id: deploymentId, leaseOwner: owner },
+    data: { leaseOwner: null, leaseUntil: null },
+  });
+}
+
+export function startDeployLeaseHeartbeat(
+  deploymentId: string,
+  owner: string,
+  log?: (message: string) => void,
+): { stop: () => void } {
+  return startIntervalHeartbeat(
+    async () => {
+      const ok = await renewDeployLease(deploymentId, owner);
+      if (!ok) {
+        throw new Error('deploy lease lost (cancelled or taken over)');
+      }
+    },
+    DEPLOY_LEASE_RENEW_MS,
+    { log, stopOnError: true },
+  );
+}

--- a/src/services/internal/service/deployments.ts
+++ b/src/services/internal/service/deployments.ts
@@ -279,7 +279,7 @@ export async function getDeployment(deploymentId: string) {
   if (!deployment) throw new NotFoundError('Deployment not found.');
   const logs = (deployment.logs as unknown as LogLine[] | null) ?? [];
   const userLabels = await resolveTriggeredByLabels([deployment.triggeredBy]);
-  const { service, ...rest } = deployment;
+  const { service, leaseOwner: _leaseOwner, leaseUntil: _leaseUntil, ...rest } = deployment;
   const wildcardDomain = service.server?.settings?.wildcardDomain?.trim() || null;
   return {
     ...rest,
@@ -310,7 +310,7 @@ export async function cancelDeployment(deploymentId: string) {
 
   const updated = await prisma.deployment.updateMany({
     where: { id: deploymentId, status: { in: ['QUEUED', 'IN_PROGRESS'] } },
-    data: { status: 'CANCELLED', finishedAt: new Date() },
+    data: { status: 'CANCELLED', finishedAt: new Date(), leaseOwner: null, leaseUntil: null },
   });
   if (updated.count === 0) {
     throw new AppError('Deployment can no longer be cancelled.');

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 import { serverEnv } from '../src/lib/env';
-import { receiveMessages, deleteMessage } from '../src/lib/queue/sqs';
+import { receiveMessages, deleteMessage, withVisibilityHeartbeat } from '../src/lib/queue/sqs';
 import type { QueueMessage, QueueName } from '../src/lib/queue/messages';
 import { dispatch, loadHandlers } from './handlers';
 import { NotFoundError } from '../src/lib/errors';
@@ -27,8 +27,17 @@ async function handleMessage(name: QueueName, raw: Message): Promise<void> {
 
   const log = (m: string) => console.log(`[worker:${name}:${parsed.type}] ${m}`);
   try {
-    await dispatch(parsed, { log });
-    await deleteMessage(name, raw.ReceiptHandle);
+    await withVisibilityHeartbeat(
+      name,
+      raw.ReceiptHandle,
+      () => dispatch(parsed, { log }),
+      (m) => console.warn(`[worker:${name}:${parsed.type}] ${m}`),
+    );
+    try {
+      await deleteMessage(name, raw.ReceiptHandle);
+    } catch (err) {
+      log(`delete failed: ${err instanceof Error ? err.message : err}`);
+    }
     log('done');
   } catch (err) {
     console.error(`[worker:${name}:${parsed.type}] failed:`, err instanceof Error ? err.message : err);


### PR DESCRIPTION
## Summary
- SQS visibility timed out at 15 minutes, so a second worker started the same in-progress deploy and raced `docker compose up`.
- Extend message visibility while the job runs, and take a DB lease so a redelivered message cannot run in parallel.
- If finishing loses a race against `FAILED`, log the real status instead of `Deployment cancelled.`

## Test plan
- [x] Unit tests: `pnpm exec vitest run src/lib/queue/__tests__/visibility-heartbeat.test.ts src/services/internal/deploy/__tests__/lease.test.ts`
- [x] Apply the `deployment_lease` migration on staging before the new worker starts
- [x] Deploy an app whose build takes >15 minutes and confirm a single `Deploying …` line, status `FINISHED`, no late `Deployment cancelled.`
- [x] Redeploy the same commit and confirm it still completes quickly using the cached image


Made with [Cursor](https://cursor.com)