### PR TITLE
Persist Stripe promotion codes on subscriptions

### DIFF
--- a/prisma/migrations/20260821120000_subscription_promotion/migration.sql
+++ b/prisma/migrations/20260821120000_subscription_promotion/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "Subscription" ADD COLUMN "promotionCode" TEXT;
+ALTER TABLE "Subscription" ADD COLUMN "stripeCouponId" TEXT;
+ALTER TABLE "Subscription" ADD COLUMN "hasActivePromotion" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "Subscription" ADD COLUMN "promotionCodeEver" TEXT;
+ALTER TABLE "Subscription" ADD COLUMN "promotionCodeAppliedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1091,6 +1091,16 @@ model Subscription {
   cancelAtPeriodEnd        Boolean   @default(false)
   currentPeriodEnd         DateTime?
   canceledAt               DateTime?
+  /// Human promo code currently on the Stripe subscription (null when none active).
+  promotionCode            String?
+  /// Stripe coupon id currently applied (null when none active).
+  stripeCouponId           String?
+  /// True while Stripe still has an active discount on the subscription.
+  hasActivePromotion       Boolean   @default(false)
+  /// First promo code ever seen (sticky; not cleared when a once-coupon expires).
+  promotionCodeEver        String?
+  /// When we first recorded a promotion on this subscription (sticky).
+  promotionCodeAppliedAt   DateTime?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/scripts/backfill-subscription-promotions.ts
+++ b/scripts/backfill-subscription-promotions.ts
@@ -1,0 +1,112 @@
+/**
+ * One-off: backfill Subscription promotion columns from Stripe.
+ *
+ * Usage (from peon-app root, with prod/staging .env):
+ *   pnpm exec tsx scripts/backfill-subscription-promotions.ts
+ *   pnpm exec tsx scripts/backfill-subscription-promotions.ts --dry-run
+ */
+import 'dotenv/config';
+
+import type Stripe from 'stripe';
+
+import { prisma } from '../src/lib/prisma';
+import { getStripe } from '../src/lib/stripe/client';
+import {
+  extractSubscriptionPromotion,
+  mergePromotionFields,
+  SUBSCRIPTION_DISCOUNT_EXPAND,
+} from '../src/lib/billing/promotion';
+
+async function promotionFromInvoice(subscriptionId: string) {
+  const stripe = getStripe();
+  const invoices = await stripe.invoices.list({
+    subscription: subscriptionId,
+    limit: 5,
+    expand: ['data.discounts', 'data.discounts.promotion_code', 'data.discounts.source.coupon'],
+  });
+
+  for (const invoice of invoices.data) {
+    const discounts = (invoice.discounts ?? []) as Array<string | Stripe.Discount>;
+    const snap = extractSubscriptionPromotion({ discounts });
+    if (snap.promotionCode || snap.stripeCouponId || snap.hasActivePromotion) {
+      return snap;
+    }
+  }
+  return null;
+}
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run');
+  const rows = await prisma.subscription.findMany({
+    where: { stripeSubscriptionId: { not: null } },
+    select: {
+      id: true,
+      workspaceId: true,
+      stripeSubscriptionId: true,
+      promotionCodeEver: true,
+      promotionCodeAppliedAt: true,
+    },
+    orderBy: { createdAt: 'asc' },
+  });
+
+  console.log(`Found ${rows.length} subscriptions with Stripe ids (dryRun=${dryRun})`);
+  const stripe = getStripe();
+  let updated = 0;
+  let fromInvoice = 0;
+
+  for (const row of rows) {
+    const subId = row.stripeSubscriptionId!;
+    try {
+      const stripeSub = await stripe.subscriptions.retrieve(subId, {
+        expand: [...SUBSCRIPTION_DISCOUNT_EXPAND],
+      });
+      let live = extractSubscriptionPromotion(stripeSub);
+      if (!live.promotionCode && !live.stripeCouponId && !live.hasActivePromotion) {
+        const invoiceSnap = await promotionFromInvoice(subId);
+        if (invoiceSnap) {
+          live = invoiceSnap;
+          fromInvoice += 1;
+        }
+      }
+
+      const merged = mergePromotionFields(
+        {
+          promotionCodeEver: row.promotionCodeEver,
+          promotionCodeAppliedAt: row.promotionCodeAppliedAt,
+        },
+        live,
+      );
+
+      if (
+        !merged.hasActivePromotion &&
+        !merged.promotionCodeEver &&
+        !merged.promotionCodeAppliedAt
+      ) {
+        continue;
+      }
+
+      console.log(
+        `${row.workspaceId} ${subId} -> code=${merged.promotionCode ?? '-'} ever=${merged.promotionCodeEver ?? '-'} active=${merged.hasActivePromotion}`,
+      );
+
+      if (!dryRun) {
+        await prisma.subscription.update({
+          where: { id: row.id },
+          data: merged,
+        });
+      }
+      updated += 1;
+    } catch (err) {
+      console.error(`Failed ${subId}:`, err instanceof Error ? err.message : err);
+    }
+  }
+
+  console.log(`Done. wrote=${updated} fromInvoiceFallback=${fromInvoice}`);
+  await prisma.$disconnect();
+}
+
+main().catch(async (err) => {
+  console.error(err);
+  await prisma.$disconnect();
+  process.exit(1);
+});

--- a/src/lib/billing/__tests__/promotion.test.ts
+++ b/src/lib/billing/__tests__/promotion.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import type Stripe from 'stripe';
+import {
+  extractSubscriptionPromotion,
+  mergePromotionFields,
+  subscriptionDiscountsNeedExpand,
+} from '@/lib/billing/promotion';
+
+function discount(partial: {
+  promotionCode?: string | { code: string } | null;
+  coupon?: string | { id: string } | null;
+}): Stripe.Discount {
+  return {
+    id: 'di_test',
+    object: 'discount',
+    checkout_session: null,
+    customer: 'cus_test',
+    customer_account: null,
+    end: null,
+    invoice: null,
+    invoice_item: null,
+    promotion_code: partial.promotionCode ?? null,
+    source: {
+      type: 'coupon',
+      coupon: partial.coupon ?? null,
+    },
+    start: 1_700_000_000,
+    subscription: 'sub_test',
+    subscription_item: null,
+  } as Stripe.Discount;
+}
+
+describe('extractSubscriptionPromotion', () => {
+  it('returns empty when there are no discounts', () => {
+    expect(extractSubscriptionPromotion({ discounts: [] })).toEqual({
+      promotionCode: null,
+      stripeCouponId: null,
+      hasActivePromotion: false,
+    });
+  });
+
+  it('marks active when discounts are unexpanded ids', () => {
+    expect(extractSubscriptionPromotion({ discounts: ['di_123'] })).toEqual({
+      promotionCode: null,
+      stripeCouponId: null,
+      hasActivePromotion: true,
+    });
+    expect(subscriptionDiscountsNeedExpand({ discounts: ['di_123'] })).toBe(true);
+  });
+
+  it('reads expanded promotion code and coupon id', () => {
+    expect(
+      extractSubscriptionPromotion({
+        discounts: [
+          discount({
+            promotionCode: { code: 'WELCOME50' },
+            coupon: { id: 'coupon_welcome' },
+          }),
+        ],
+      }),
+    ).toEqual({
+      promotionCode: 'WELCOME50',
+      stripeCouponId: 'coupon_welcome',
+      hasActivePromotion: true,
+    });
+  });
+
+  it('ignores bare promotion_code ids without expand', () => {
+    expect(
+      extractSubscriptionPromotion({
+        discounts: [discount({ promotionCode: 'promo_abc', coupon: 'coupon_x' })],
+      }),
+    ).toEqual({
+      promotionCode: null,
+      stripeCouponId: 'coupon_x',
+      hasActivePromotion: true,
+    });
+  });
+});
+
+describe('mergePromotionFields', () => {
+  it('sets sticky ever/appliedAt on first promo sighting', () => {
+    const now = new Date('2026-08-21T12:00:00.000Z');
+    expect(
+      mergePromotionFields(
+        null,
+        {
+          promotionCode: 'WELCOME50',
+          stripeCouponId: 'coupon_welcome',
+          hasActivePromotion: true,
+        },
+        now,
+      ),
+    ).toEqual({
+      promotionCode: 'WELCOME50',
+      stripeCouponId: 'coupon_welcome',
+      hasActivePromotion: true,
+      promotionCodeEver: 'WELCOME50',
+      promotionCodeAppliedAt: now,
+    });
+  });
+
+  it('keeps sticky fields after once-coupon expires', () => {
+    const appliedAt = new Date('2026-08-01T00:00:00.000Z');
+    expect(
+      mergePromotionFields(
+        {
+          promotionCodeEver: 'WELCOME50',
+          promotionCodeAppliedAt: appliedAt,
+        },
+        {
+          promotionCode: null,
+          stripeCouponId: null,
+          hasActivePromotion: false,
+        },
+      ),
+    ).toEqual({
+      promotionCode: null,
+      stripeCouponId: null,
+      hasActivePromotion: false,
+      promotionCodeEver: 'WELCOME50',
+      promotionCodeAppliedAt: appliedAt,
+    });
+  });
+});

--- a/src/lib/billing/promotion.ts
+++ b/src/lib/billing/promotion.ts
@@ -1,0 +1,106 @@
+import type Stripe from 'stripe';
+
+export type SubscriptionPromotionSnapshot = {
+  /** Human-readable promo code when expanded (e.g. WELCOME50). */
+  promotionCode: string | null;
+  /** Stripe coupon id when present. */
+  stripeCouponId: string | null;
+  /** True when the subscription currently has at least one discount. */
+  hasActivePromotion: boolean;
+};
+
+const DISCOUNT_EXPAND = [
+  'discounts',
+  'discounts.promotion_code',
+  'discounts.source.coupon',
+] as const;
+
+export const SUBSCRIPTION_DISCOUNT_EXPAND = [...DISCOUNT_EXPAND];
+
+function isDiscountObject(
+  value: string | Stripe.Discount,
+): value is Stripe.Discount {
+  return typeof value === 'object' && value !== null && 'object' in value;
+}
+
+function couponIdFromDiscount(discount: Stripe.Discount): string | null {
+  const coupon = discount.source?.coupon;
+  if (!coupon) return null;
+  if (typeof coupon === 'string') return coupon;
+  return coupon.id ?? null;
+}
+
+function promotionCodeFromDiscount(discount: Stripe.Discount): string | null {
+  const promo = discount.promotion_code;
+  if (!promo) return null;
+  if (typeof promo === 'string') return null;
+  return promo.code?.trim() || null;
+}
+
+/**
+ * Reads the first usable discount from a Stripe subscription (or invoice-like discounts list).
+ * Prefer calling with `expand: SUBSCRIPTION_DISCOUNT_EXPAND` so promotion codes resolve.
+ */
+export function extractSubscriptionPromotion(source: {
+  discounts?: Array<string | Stripe.Discount> | null;
+}): SubscriptionPromotionSnapshot {
+  const discounts = source.discounts ?? [];
+  const expanded = discounts.filter(isDiscountObject);
+  if (expanded.length === 0) {
+    return {
+      promotionCode: null,
+      stripeCouponId: null,
+      hasActivePromotion: discounts.length > 0,
+    };
+  }
+
+  const first = expanded[0]!;
+  return {
+    promotionCode: promotionCodeFromDiscount(first),
+    stripeCouponId: couponIdFromDiscount(first),
+    hasActivePromotion: true,
+  };
+}
+
+/** True when discounts exist but are still unexpanded id strings. */
+export function subscriptionDiscountsNeedExpand(source: {
+  discounts?: Array<string | Stripe.Discount> | null;
+}): boolean {
+  const discounts = source.discounts ?? [];
+  return discounts.some((d) => typeof d === 'string');
+}
+
+/**
+ * Merge a live Stripe promo snapshot into sticky local columns.
+ * Current fields follow Stripe; ever/appliedAt only set on first sighting.
+ */
+export function mergePromotionFields(
+  existing: {
+    promotionCodeEver: string | null;
+    promotionCodeAppliedAt: Date | null;
+  } | null,
+  live: SubscriptionPromotionSnapshot,
+  now = new Date(),
+): {
+  promotionCode: string | null;
+  stripeCouponId: string | null;
+  hasActivePromotion: boolean;
+  promotionCodeEver: string | null;
+  promotionCodeAppliedAt: Date | null;
+} {
+  const nextEver =
+    live.promotionCode ??
+    existing?.promotionCodeEver ??
+    null;
+  const nextAppliedAt =
+    existing?.promotionCodeAppliedAt ??
+    (live.hasActivePromotion || live.promotionCode ? now : null);
+
+  return {
+    promotionCode: live.promotionCode,
+    stripeCouponId: live.stripeCouponId,
+    hasActivePromotion: live.hasActivePromotion,
+    promotionCodeEver: nextEver,
+    promotionCodeAppliedAt: nextAppliedAt,
+  };
+}

--- a/src/services/internal/billing/billing.ts
+++ b/src/services/internal/billing/billing.ts
@@ -20,8 +20,23 @@ import {
   PEON_PRO_YEARLY_CENTS,
   yearlyDiscountPercent,
 } from '@/lib/billing/pricing';
+import {
+  extractSubscriptionPromotion,
+  mergePromotionFields,
+  SUBSCRIPTION_DISCOUNT_EXPAND,
+  subscriptionDiscountsNeedExpand,
+} from '@/lib/billing/promotion';
 
 export type BillingInterval = 'month' | 'year';
+
+async function ensureSubscriptionDiscountsExpanded(
+  stripeSub: Stripe.Subscription,
+): Promise<Stripe.Subscription> {
+  if (!subscriptionDiscountsNeedExpand(stripeSub)) return stripeSub;
+  return getStripe().subscriptions.retrieve(stripeSub.id, {
+    expand: [...SUBSCRIPTION_DISCOUNT_EXPAND],
+  });
+}
 
 async function resolvePriceId(interval: BillingInterval): Promise<string> {
   const env = serverEnv();
@@ -72,9 +87,10 @@ function nextPeriodPaidQuantity(opts: {
 
 export async function upsertSubscriptionFromStripe(
   workspaceId: string,
-  stripeSub: Stripe.Subscription,
+  stripeSubInput: Stripe.Subscription,
   customerId?: string | null,
 ) {
+  const stripeSub = await ensureSubscriptionDiscountsExpanded(stripeSubInput);
   const item = stripeSub.items.data[0];
   const customer =
     customerId ??
@@ -90,6 +106,15 @@ export async function upsertSubscriptionFromStripe(
     newQuantity,
     newPeriodEnd,
   });
+  const promotion = mergePromotionFields(
+    existing
+      ? {
+          promotionCodeEver: existing.promotionCodeEver,
+          promotionCodeAppliedAt: existing.promotionCodeAppliedAt,
+        }
+      : null,
+    extractSubscriptionPromotion(stripeSub),
+  );
 
   await prisma.subscription.upsert({
     where: { workspaceId },
@@ -106,6 +131,7 @@ export async function upsertSubscriptionFromStripe(
       cancelAtPeriodEnd: stripeSub.cancel_at_period_end,
       currentPeriodEnd: newPeriodEnd,
       canceledAt: stripeSub.canceled_at ? new Date(stripeSub.canceled_at * 1000) : null,
+      ...promotion,
     },
     update: {
       stripeCustomerId: customer ?? undefined,
@@ -119,6 +145,7 @@ export async function upsertSubscriptionFromStripe(
       cancelAtPeriodEnd: stripeSub.cancel_at_period_end,
       currentPeriodEnd: newPeriodEnd,
       canceledAt: stripeSub.canceled_at ? new Date(stripeSub.canceled_at * 1000) : null,
+      ...promotion,
     },
   });
 
@@ -242,7 +269,9 @@ export const BillingService = {
     if (billingOn && sub?.stripeSubscriptionId) {
       try {
         const stripe = getStripe();
-        const stripeSub = await stripe.subscriptions.retrieve(sub.stripeSubscriptionId);
+        const stripeSub = await stripe.subscriptions.retrieve(sub.stripeSubscriptionId, {
+          expand: [...SUBSCRIPTION_DISCOUNT_EXPAND],
+        });
         await upsertSubscriptionFromStripe(workspaceId, stripeSub);
         sub = await prisma.subscription.findUnique({ where: { workspaceId } });
       } catch {
@@ -707,7 +736,9 @@ export async function handleStripeWebhookEvent(event: Stripe.Event) {
       const stripe = getStripe();
       const subId =
         typeof session.subscription === 'string' ? session.subscription : session.subscription.id;
-      const stripeSub = await stripe.subscriptions.retrieve(subId);
+      const stripeSub = await stripe.subscriptions.retrieve(subId, {
+        expand: [...SUBSCRIPTION_DISCOUNT_EXPAND],
+      });
       await upsertSubscriptionFromStripe(workspaceId, stripeSub);
       break;
     }
@@ -736,7 +767,9 @@ export async function handleStripeWebhookEvent(event: Stripe.Event) {
       if (!subRef) break;
       const subId = typeof subRef === 'string' ? subRef : subRef.id;
       const stripe = getStripe();
-      const stripeSub = await stripe.subscriptions.retrieve(subId);
+      const stripeSub = await stripe.subscriptions.retrieve(subId, {
+        expand: [...SUBSCRIPTION_DISCOUNT_EXPAND],
+      });
       const workspaceId = stripeSub.metadata?.workspaceId;
       if (workspaceId) {
         await upsertSubscriptionFromStripe(workspaceId, stripeSub);


### PR DESCRIPTION
## Summary
- Add sticky + current promotion fields on `Subscription` (`promotionCode`, `stripeCouponId`, `hasActivePromotion`, `promotionCodeEver`, `promotionCodeAppliedAt`).
- Expand discounts in Stripe retrieves / webhook upserts so promo codes like `WELCOME50` are stored for analytics.
- Include a one-off backfill script for existing paid workspaces (`scripts/backfill-subscription-promotions.ts`).

## Test plan
- [ ] Unit tests: `pnpm exec vitest run src/lib/billing/__tests__/promotion.test.ts`
- [ ] Apply migration on staging
- [ ] Subscribe with `WELCOME50` and confirm local `Subscription` gets code + `hasActivePromotion=true`
- [ ] After a once-coupon expires (or on a later webhook), sticky `promotionCodeEver` / `promotionCodeAppliedAt` remain
- [ ] Dry-run backfill: `pnpm exec tsx scripts/backfill-subscription-promotions.ts --dry-run`


Made with [Cursor](https://cursor.com)