### PR TITLE
fix(deploy): close control-queue suspension race

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -436,11 +436,14 @@ A suspended service (`Service.suspendedAt`) must not be brought back up by anyth
 | PR preview (`deploy/preview.ts`) | skipped; teardown on PR close is still allowed |
 | Cron scheduler (`worker/scheduler.ts`) | tasks and backups filtered to live services |
 | `runDeployment` entry (`deploy/engine.ts`) | cancels and releases the server slot |
+| `controlService` entry (`deploy/engine.ts`) | skips stale `start` / `restart` / `resume` if `suspendedAt` is set |
 | Host reboot | no guard needed — compose renders `restart: unless-stopped` |
 
 The first four guards sit at `Deployment` creation time. `runDeployment` re-checks on entry
-because desired state can flip while a deployment waits for a server-queue slot, which is the
-one window the creation-time guards cannot cover.
+because desired state can flip while a deployment waits for a server-queue slot.
+`controlService` re-checks the same way for queued `service.control` jobs: a later suspend
+must win over a stale start/restart/resume so containers stay down and status is not
+overwritten to `RUNNING`.
 
 Every one of those paths reads `Service.suspendedAt` through `service/suspension.ts` rather than
 inline: `assertNotSuspended(svc, activity)` for the paths that answer a user (one `409` wording),

--- a/src/services/internal/deploy/__tests__/control-service-suspension.test.ts
+++ b/src/services/internal/deploy/__tests__/control-service-suspension.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    service: { findUnique: vi.fn(), update: vi.fn() },
+  },
+}));
+
+vi.mock('@/lib/ssh', () => ({
+  sshPool: { exec: vi.fn() },
+  sshTargetForServer: vi.fn(),
+}));
+
+import { prisma } from '@/lib/prisma';
+import { sshPool, sshTargetForServer } from '@/lib/ssh';
+import { controlService } from '@/services/internal/deploy/engine';
+
+const serviceFindUnique = vi.mocked(prisma.service.findUnique);
+const serviceUpdate = vi.mocked(prisma.service.update);
+const exec = vi.mocked(sshPool.exec);
+const targetForServer = vi.mocked(sshTargetForServer);
+
+function service(suspendedAt: Date | null) {
+  return {
+    id: 'svc1',
+    name: 'app',
+    uuid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    serverId: 'srv1',
+    suspendedAt,
+  } as never;
+}
+
+describe('controlService suspension re-check', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    targetForServer.mockResolvedValue({ host: 'h', user: 'u' } as never);
+    exec.mockResolvedValue({ code: 0, stdout: '', stderr: '' } as never);
+    serviceUpdate.mockResolvedValue({} as never);
+  });
+
+  // Resume clears suspendedAt at enqueue time. If the operator suspends again
+  // before the worker runs, a stale resume must not compose-up or flip status.
+  it('skips a stale resume when the service was re-suspended', async () => {
+    serviceFindUnique.mockResolvedValue(service(new Date('2026-01-01T00:00:00Z')));
+
+    await controlService('svc1', 'resume');
+
+    expect(exec).not.toHaveBeenCalled();
+    expect(serviceUpdate).not.toHaveBeenCalled();
+  });
+
+  it('skips a stale start when the service was suspended after enqueue', async () => {
+    serviceFindUnique.mockResolvedValue(service(new Date('2026-01-01T00:00:00Z')));
+
+    await controlService('svc1', 'start');
+
+    expect(exec).not.toHaveBeenCalled();
+    expect(serviceUpdate).not.toHaveBeenCalled();
+  });
+
+  it('skips a stale restart when the service is suspended', async () => {
+    serviceFindUnique.mockResolvedValue(service(new Date('2026-01-01T00:00:00Z')));
+
+    await controlService('svc1', 'restart');
+
+    expect(exec).not.toHaveBeenCalled();
+    expect(serviceUpdate).not.toHaveBeenCalled();
+  });
+
+  it('still applies suspend while suspended (idempotent host stop)', async () => {
+    serviceFindUnique.mockResolvedValue(service(new Date('2026-01-01T00:00:00Z')));
+
+    await controlService('svc1', 'suspend');
+
+    expect(exec).toHaveBeenCalled();
+    expect(serviceUpdate).toHaveBeenCalledWith({
+      where: { id: 'svc1' },
+      data: { status: 'SUSPENDED' },
+    });
+  });
+
+  it('applies resume when suspension was cleared', async () => {
+    serviceFindUnique.mockResolvedValue(service(null));
+
+    await controlService('svc1', 'resume');
+
+    expect(exec).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringMatching(/^cd '[^']+' && docker compose up -d$/),
+    );
+    expect(serviceUpdate).toHaveBeenCalledWith({
+      where: { id: 'svc1' },
+      data: { status: 'RUNNING' },
+    });
+  });
+
+  it('shell-quotes the service directory on the host command', async () => {
+    serviceFindUnique.mockResolvedValue(service(null));
+
+    await controlService('svc1', 'stop');
+
+    const cmd = exec.mock.calls[0]?.[1] as string;
+    expect(cmd).toMatch(
+      /^cd '\/data\/peon\/services\/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' && /,
+    );
+  });
+});

--- a/src/services/internal/deploy/engine.ts
+++ b/src/services/internal/deploy/engine.ts
@@ -987,8 +987,20 @@ export async function controlService(
 ): Promise<void> {
   const svc = await prisma.service.findUnique({ where: { id: serviceId } });
   if (!svc || !svc.serverId) throw new Error('Service or server missing.');
+
+  // Desired state can flip while a control job waits in the queue. A stale
+  // start/restart/resume must not bring containers back up (or overwrite
+  // status to RUNNING) after a later suspend. stop/suspend always move toward
+  // scaled-to-zero and remain safe to apply.
+  if (
+    (action === 'start' || action === 'restart' || action === 'resume') &&
+    isSuspended(svc)
+  ) {
+    return;
+  }
+
   const target = await sshTargetForServer(svc.serverId);
-  const dir = serviceDir(svc);
+  const dir = shellSingleQuote(serviceDir(svc));
   const res = await sshPool.exec(target, `cd ${dir} && ${composeCommandFor(action)}`);
 
   // sshPool.exec resolves with an exit code instead of throwing, so a failed


### PR DESCRIPTION
## Summary
- Re-check `Service.suspendedAt` at `controlService` entry so a stale queued `start` / `restart` / `resume` cannot bring containers back up (or write `RUNNING`) after a later suspend — the gap left after #45’s deploy-path re-check.
- Shell-quote the compose working directory in `controlService` (same as `teardownService`).
- Document the guard in `docs/architecture.md` and cover the race with unit tests.

## Test plan
- [x] `pnpm exec vitest run src/services/internal/deploy/__tests__/control-service-suspension.test.ts`
- [ ] Manual (optional): queue Resume, then Suspend before the worker runs — containers should stay down and status should remain suspended


Made with [Cursor](https://cursor.com)