### PR TITLE
fix: add ElasticMQ to Docker Compose for local SQS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,13 +44,24 @@ AWS_REGION=us-east-1
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 
-# --- Queue (AWS SQS) ---
-# Leave SQS_ENDPOINT empty to use real AWS SQS (recommended for local + prod).
-# Only set SQS_ENDPOINT if you need a custom SQS-compatible endpoint.
+# --- Queue (AWS SQS or local ElasticMQ) ---
+# Option A — real AWS SQS (production / cloud): leave SQS_ENDPOINT empty and
+# set the two queue URLs to your AWS SQS URLs. Use real AWS_* credentials above.
 SQS_ENDPOINT=
 SQS_REGION=us-east-1
 SQS_DEPLOYMENT_QUEUE_URL=
 SQS_TASKS_QUEUE_URL=
+#
+# Option B — local ElasticMQ (no AWS account):
+#   docker compose --profile sqs up -d
+# Then use:
+# SQS_ENDPOINT=http://localhost:9324
+# SQS_REGION=us-east-1
+# SQS_DEPLOYMENT_QUEUE_URL=http://localhost:9324/000000000000/peon-deployments
+# SQS_TASKS_QUEUE_URL=http://localhost:9324/000000000000/peon-tasks
+# AWS_ACCESS_KEY_ID=local
+# AWS_SECRET_ACCESS_KEY=local
+# (The `full` Compose profile overrides these to http://elasticmq:9324 for containers.)
 
 # --- Worker ---
 WORKER_POLL_WAIT_SECONDS=20

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ cp .env.example .env
 - Node.js 22.x
 - [pnpm](https://pnpm.io/)
 - PostgreSQL
-- AWS credentials with access to SQS (SES/S3 optional for email and assets)
+- A queue: real AWS SQS, or local ElasticMQ via Compose (SES/S3 optional for email and assets)
 - A Linux server reachable over SSH (to exercise real deployments)
 
 Fill in at least:
@@ -90,14 +90,13 @@ Fill in at least:
 - `JWT_SECRET` (`openssl rand -hex 32`)
 - `ENCRYPTION_KEY` (`openssl rand -base64 32`)
 - `SQS_DEPLOYMENT_QUEUE_URL` / `SQS_TASKS_QUEUE_URL`
-- `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION`
+- For real AWS SQS: `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` (leave `SQS_ENDPOINT` empty)
+- For local ElasticMQ: see the ElasticMQ block in `.env.example`
 
-Leave `SQS_ENDPOINT` empty to use real AWS SQS. See `.env.example` for the full list.
-
-Optional local Postgres via Compose:
+Optional local Postgres + ElasticMQ via Compose:
 
 ```bash
-docker compose --profile db up -d
+docker compose --profile db --profile sqs up -d
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Security reports: see [SECURITY.md](./SECURITY.md).
 - One-click service templates (databases, compose stacks, and more)
 - Workspace / project tenancy with role-based access
 - Background worker for deployments, backups, and async tasks
-- Self-host with your own Postgres and AWS SQS (SES/S3 optional for email and assets)
+- Self-host with your own Postgres and AWS SQS or local ElasticMQ (SES/S3 optional for email and assets)
 
 ## Related repositories
 
@@ -32,7 +32,8 @@ Security reports: see [SECURITY.md](./SECURITY.md).
 - Node.js 20+
 - [pnpm](https://pnpm.io/)
 - PostgreSQL (run your own local container or managed instance)
-- AWS credentials with access to SQS (and SES/S3 if you use those features)
+- A queue: real AWS SQS, or local ElasticMQ via Compose (no AWS account needed)
+- SES/S3 credentials only if you use email / object storage features
 - A Linux server reachable over SSH (to exercise real deployments)
 
 ## Quick start
@@ -41,7 +42,10 @@ Security reports: see [SECURITY.md](./SECURITY.md).
 git clone https://github.com/Peon-sh/Peon.git
 cd Peon
 pnpm install
-cp .env.example .env   # set DATABASE_URL, JWT_SECRET, ENCRYPTION_KEY, AWS + SQS URLs
+cp .env.example .env   # set DATABASE_URL, JWT_SECRET, ENCRYPTION_KEY, and SQS URLs
+
+# Optional local dependencies (Postgres + ElasticMQ):
+docker compose --profile db --profile sqs up -d
 
 pnpm db:migrate
 pnpm dev               # http://localhost:3000
@@ -50,15 +54,17 @@ pnpm schedule          # cron → enqueue (exactly one instance)
 pnpm socket            # terminal WebSocket
 ```
 
-Leave `SQS_ENDPOINT` empty so the app talks to real AWS SQS. See `.env.example` for the full list of environment variables.
+For local ElasticMQ, set the SQS block in `.env` as documented in `.env.example`.
+Leave `SQS_ENDPOINT` empty to use real AWS SQS instead.
 
 ### Optional Docker Compose
 
-Compose is optional and not used for day-to-day local development. Profiles:
+Compose is optional. Profiles:
 
 ```bash
-docker compose --profile db up -d      # Postgres only, if you want it
-docker compose --profile full up -d    # containerized app + worker + schedule + socket
+docker compose --profile db up -d       # Postgres only
+docker compose --profile sqs up -d      # ElasticMQ (local SQS on :9324)
+docker compose --profile full up -d     # app + worker + schedule + socket + ElasticMQ
 ```
 
 ## Scripts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,24 @@
 # Optional self-host / production-like stack for Peon.
-# Local development does NOT require this file — run Postgres yourself and use
-# real AWS SQS (leave SQS_ENDPOINT empty). App + processes run on the host:
 #
-#   pnpm dev
-#   pnpm worker     # SQS job consumer (scale freely)
-#   pnpm schedule   # cron → enqueue (run exactly one)
-#   pnpm socket     # terminal WebSocket
+# Day-to-day local development usually runs the app on the host:
 #
-# Full containerized deploy still needs DATABASE_URL and AWS credentials in
-# `.env` (SQS, SES, S3).
+#   docker compose --profile db up -d       # Postgres
+#   docker compose --profile sqs up -d      # ElasticMQ (local SQS)
+#   pnpm dev / pnpm worker / pnpm schedule / pnpm socket
+#
+# Or run the full containerized stack (app + worker + schedule + socket + SQS):
+#
+#   docker compose --profile full up -d
+#
+# Point `.env` at ElasticMQ when using the local queue (see `.env.example`),
+# or leave SQS_ENDPOINT empty to use real AWS SQS.
+
+x-local-sqs-env: &local-sqs-env
+  SQS_ENDPOINT: http://elasticmq:9324
+  SQS_DEPLOYMENT_QUEUE_URL: http://elasticmq:9324/000000000000/peon-deployments
+  SQS_TASKS_QUEUE_URL: http://elasticmq:9324/000000000000/peon-tasks
+  AWS_ACCESS_KEY_ID: local
+  AWS_SECRET_ACCESS_KEY: local
 
 services:
   postgres:
@@ -31,6 +41,16 @@ services:
       retries: 10
     profiles: ["db"]
 
+  elasticmq:
+    image: softwaremill/elasticmq-native
+    container_name: peon-elasticmq
+    restart: unless-stopped
+    ports:
+      - "9324:9324"
+    volumes:
+      - ./docker/elasticmq.conf:/opt/elasticmq.conf:ro
+    profiles: ["sqs", "full"]
+
   app:
     build:
       context: .
@@ -40,8 +60,12 @@ services:
     command: ["pnpm", "start"]
     env_file:
       - .env
+    environment:
+      <<: *local-sqs-env
     ports:
       - "3000:3000"
+    depends_on:
+      - elasticmq
     profiles: ["full"]
 
   worker:
@@ -53,6 +77,10 @@ services:
     command: ["node", "--import", "tsx", "worker/index.ts"]
     env_file:
       - .env
+    environment:
+      <<: *local-sqs-env
+    depends_on:
+      - elasticmq
     profiles: ["full"]
 
   schedule:
@@ -64,6 +92,10 @@ services:
     command: ["node", "--import", "tsx", "worker/schedule.ts"]
     env_file:
       - .env
+    environment:
+      <<: *local-sqs-env
+    depends_on:
+      - elasticmq
     profiles: ["full"]
 
   socket:

--- a/docker/elasticmq.conf
+++ b/docker/elasticmq.conf
@@ -1,0 +1,25 @@
+include "application"
+
+queues {
+  peon-deployments {
+    defaultVisibilityTimeout = 10 seconds
+    delay = 0 seconds
+    receiveMessageWait = 0 seconds
+    deadLettersQueue {
+      name = "peon-deployments-dlq"
+      maxReceiveCount = 3
+    }
+  }
+  peon-deployments-dlq {}
+
+  peon-tasks {
+    defaultVisibilityTimeout = 10 seconds
+    delay = 0 seconds
+    receiveMessageWait = 0 seconds
+    deadLettersQueue {
+      name = "peon-tasks-dlq"
+      maxReceiveCount = 3
+    }
+  }
+  peon-tasks-dlq {}
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -118,7 +118,7 @@ Scale workers horizontally. Run a **single** scheduler. The web app can be scale
 | ORM | **Prisma 7** + `@prisma/adapter-pg` | Client generated under `src/lib/prisma/generated/client` (gitignored; `postinstall` / CI / Docker run `prisma generate`) |
 | Validation | Zod **4** | `src/schemas/*` |
 | Auth tokens | `jose` (JWT HS256), `bcryptjs` | Cookie + `AuthSession` rows |
-| Queues | AWS SQS (`@aws-sdk/client-sqs`) | Optional `SQS_ENDPOINT` for LocalStack |
+| Queues | AWS SQS (`@aws-sdk/client-sqs`) | Optional `SQS_ENDPOINT` for ElasticMQ / LocalStack |
 | Object storage | S3 | Previews, avatars, backup storage configs |
 | Email | SES or `test` driver | Worker job `email.send` |
 | AI / MCP | Vercel AI SDK + `@modelcontextprotocol/sdk` | Chat agent + hosted MCP |


### PR DESCRIPTION
## Summary
- Closes #59 by adding ElasticMQ (`softwaremill/elasticmq-native`) to `docker-compose.yml` with pre-created `peon-deployments` / `peon-tasks` queues (and DLQs).
- New `sqs` profile for host-based local dev; `full` profile starts ElasticMQ and points `app` / `worker` / `schedule` at `http://elasticmq:9324`.
- Updates README, CONTRIBUTING, `.env.example`, and architecture docs so self-hosting no longer assumes a real AWS SQS account.

## Test plan
- [ ] `docker compose --profile sqs config` resolves ElasticMQ + `docker/elasticmq.conf`
- [ ] `docker compose --profile sqs up -d` exposes SQS on `localhost:9324`
- [ ] With ElasticMQ env from `.env.example`, `pnpm worker` can poll local queues
- [ ] `docker compose --profile full config` shows app/worker/schedule `SQS_*` overrides to `http://elasticmq:9324`


Made with [Cursor](https://cursor.com)