### PR TITLE
Show YouTube tutorial after onboarding

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -6,6 +6,7 @@ import { AppSidebar } from '@/components/app/app-sidebar';
 import { AppHeader } from '@/components/app/app-header';
 import { CommandPalette } from '@/components/app/command-palette';
 import { BottomRightNotices } from '@/components/app/bottom-right-notices';
+import { WelcomeTutorialDialog } from '@/components/app/welcome-tutorial-dialog';
 import { useAuthStore } from '@/store/auth';
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
@@ -35,6 +36,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
         </div>
       </SidebarInset>
       <BottomRightNotices />
+      <WelcomeTutorialDialog />
     </SidebarProvider>
   );
 }

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -17,6 +17,7 @@ import { getBillingSummary } from '@/services/api/billing';
 import { publicEnv } from '@/lib/env';
 import { InAppSubscribeForm } from '@/components/billing/in-app-subscribe-form';
 import { yearlyDiscountPercent } from '@/lib/billing/pricing';
+import { markWelcomeTutorialPending } from '@/lib/welcome-tutorial';
 
 const BASE_STEPS = [
   { id: 'workspace', label: 'Workspace', icon: Sparkles },
@@ -55,6 +56,7 @@ export default function OnboardingPage() {
   const finishMut = useMutation({
     mutationFn: completeOnboarding,
     onSuccess: async (_data, destination: string | void) => {
+      markWelcomeTutorialPending();
       await qc.invalidateQueries({ queryKey: ['auth', 'me'] });
       router.replace(typeof destination === 'string' && destination ? destination : '/dashboard');
     },

--- a/src/components/app/welcome-tutorial-dialog.tsx
+++ b/src/components/app/welcome-tutorial-dialog.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalDescription,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+} from '@/components/app/modal';
+import {
+  dismissWelcomeTutorial,
+  shouldShowWelcomeTutorial,
+} from '@/lib/welcome-tutorial';
+
+const YOUTUBE_VIDEO_ID = 's-o9yqc1SUc';
+
+/**
+ * One-shot YouTube tutorial after a user completes onboarding.
+ * Triggered via localStorage flag set in the onboarding finish flow.
+ */
+export function WelcomeTutorialDialog() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (shouldShowWelcomeTutorial()) {
+      setOpen(true);
+    }
+  }, []);
+
+  const dismiss = () => {
+    dismissWelcomeTutorial();
+    setOpen(false);
+  };
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) dismiss();
+        else setOpen(true);
+      }}
+    >
+      <ModalContent size="xl" className="sm:max-w-3xl">
+        <ModalHeader>
+          <ModalTitle>Quick tour of Peon</ModalTitle>
+          <ModalDescription>
+            Watch this short walkthrough to see how to connect a server and deploy your first app.
+          </ModalDescription>
+        </ModalHeader>
+        <ModalBody className="p-0 sm:px-4 sm:pb-2">
+          <div className="bg-muted relative aspect-video w-full overflow-hidden rounded-md">
+            <iframe
+              src={`https://www.youtube.com/embed/${YOUTUBE_VIDEO_ID}?rel=0`}
+              title="Peon product tutorial"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              allowFullScreen
+              className="absolute inset-0 h-full w-full border-0"
+            />
+          </div>
+        </ModalBody>
+        <ModalFooter>
+          <Button type="button" onClick={dismiss}>
+            Got it
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/lib/__tests__/welcome-tutorial.test.ts
+++ b/src/lib/__tests__/welcome-tutorial.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  WELCOME_TUTORIAL_STORAGE_KEY,
+  dismissWelcomeTutorial,
+  markWelcomeTutorialPending,
+  shouldShowWelcomeTutorial,
+} from '@/lib/welcome-tutorial';
+
+describe('welcome tutorial storage', () => {
+  const store = new Map<string, string>();
+
+  beforeEach(() => {
+    store.clear();
+    vi.stubGlobal('window', {});
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        store.set(key, value);
+      },
+      removeItem: (key: string) => {
+        store.delete(key);
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('is hidden until marked pending', () => {
+    expect(shouldShowWelcomeTutorial()).toBe(false);
+    markWelcomeTutorialPending();
+    expect(shouldShowWelcomeTutorial()).toBe(true);
+    expect(store.get(WELCOME_TUTORIAL_STORAGE_KEY)).toBe('1');
+  });
+
+  it('stays hidden after dismiss', () => {
+    markWelcomeTutorialPending();
+    dismissWelcomeTutorial();
+    expect(shouldShowWelcomeTutorial()).toBe(false);
+    expect(store.get(WELCOME_TUTORIAL_STORAGE_KEY)).toBe('0');
+  });
+});

--- a/src/lib/welcome-tutorial.ts
+++ b/src/lib/welcome-tutorial.ts
@@ -1,0 +1,17 @@
+/** Set to `'1'` when onboarding finishes; cleared when the user dismisses the dialog. */
+export const WELCOME_TUTORIAL_STORAGE_KEY = 'peon.welcomeTutorial';
+
+export function shouldShowWelcomeTutorial(): boolean {
+  if (typeof window === 'undefined') return false;
+  return localStorage.getItem(WELCOME_TUTORIAL_STORAGE_KEY) === '1';
+}
+
+export function markWelcomeTutorialPending(): void {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(WELCOME_TUTORIAL_STORAGE_KEY, '1');
+}
+
+export function dismissWelcomeTutorial(): void {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(WELCOME_TUTORIAL_STORAGE_KEY, '0');
+}


### PR DESCRIPTION
## Summary
- After onboarding completes, set a one-shot localStorage flag and open a welcome modal with the Peon YouTube walkthrough (`s-o9yqc1SUc`).
- Modal lives in the authenticated app shell so it appears whether the user lands on `/dashboard` or a new project.
- Dismiss (X or “Got it”) clears the flag so existing / returning users are not prompted again.

## Test plan
- [ ] Complete onboarding (or skip project step) and confirm the tutorial modal opens with the embedded video
- [ ] Close via X or “Got it” and confirm it does not reappear on refresh / navigation
- [ ] Confirm existing onboarded sessions without the flag never see the modal
- [ ] `pnpm exec vitest run src/lib/__tests__/welcome-tutorial.test.ts`


Made with [Cursor](https://cursor.com)