### PR TITLE
Add PostHog onboarding analytics and funnel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,10 @@ GITHUB_APP_CLIENT_ID=
 GITHUB_APP_CLIENT_SECRET=
 SENTRY_DSN=
 
+# PostHog product analytics (leave empty to disable)
+NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=
+NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+
 # --- Workspace agent chat ---
 # Configure LLM API keys per workspace in Settings → LLMs.
 

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,0 +1,11 @@
+import posthog from 'posthog-js';
+
+const token = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN?.trim();
+
+if (token) {
+  posthog.init(token, {
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
+    defaults: '2026-05-30',
+    person_profiles: 'identified_only',
+  });
+}

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "next": "16.3.2",
     "node-ssh": "^13.2.1",
     "playwright": "^1.62.1",
+    "posthog-js": "^1.418.16",
     "radix-ui": "^1.6.7",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
       playwright:
         specifier: ^1.62.1
         version: 1.62.1
+      posthog-js:
+        specifier: ^1.418.16
+        version: 1.418.16
       radix-ui:
         specifier: ^1.6.7
         version: 1.6.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1115,6 +1118,15 @@ packages:
 
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
+  '@posthog/browser-common@0.5.1':
+    resolution: {integrity: sha512-zdxfms2pIYJOMqEukqfYWLuXn/xawewR6FEMk2yrgvGCf/Ip9JiguN1n/Wz4WAhBYxw8E8hKEe3gC27kAxZUjQ==}
+
+  '@posthog/core@1.48.10':
+    resolution: {integrity: sha512-Y70zhdQFNMwHHZk9MW44MJUR1DyFm0Cn3DOtd+wQYnGv+kX+qc6CA+pBtEmZe2XD0K9uuOKiz2LJwzaq/wz0FA==}
+
+  '@posthog/types@1.405.3':
+    resolution: {integrity: sha512-HApKJSYfwo/z2KIVB98E/8XwEL3pTXawBp0AB7FKRVtStz9hizRlaO6n9RR7sjgXLnOLvqj++CGsZb8rQbOS2g==}
 
   '@prisma/adapter-pg@7.9.1':
     resolution: {integrity: sha512-Ho2RK1KanQxLNSC0sR5bpiiVep10sWPLXCcxK+KXfI/Q69TMRbiafSvLPv3V9snimX72rMCqGlyJ4sBO4lKTAw==}
@@ -2534,6 +2546,9 @@ packages:
   '@types/ssh2@1.15.5':
     resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -3190,6 +3205,9 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  core-js@3.50.0:
+    resolution: {integrity: sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==}
+
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
@@ -3414,6 +3432,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dompurify@3.4.14:
+    resolution: {integrity: sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==}
 
   dot-prop@6.0.1:
     resolution: {integrity: sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==}
@@ -3755,6 +3776,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.4.9:
+    resolution: {integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==}
 
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
@@ -5077,6 +5101,9 @@ packages:
     resolution: {integrity: sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==}
     engines: {node: '>=12'}
 
+  posthog-js@1.418.16:
+    resolution: {integrity: sha512-/xnf6/PfCpRttAUr9R809L0qb52DsDg+LsuVlafKKDSqB1jO3dvCd1lDMgHsDZARcojI2RXfYZbsXHIfR10hVQ==}
+
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
@@ -5084,6 +5111,14 @@ packages:
   powershell-utils@0.2.0:
     resolution: {integrity: sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==}
     engines: {node: '>=20'}
+
+  preact@10.29.8:
+    resolution: {integrity: sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==}
+    peerDependencies:
+      preact-render-to-string: '>=5'
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -5204,6 +5239,9 @@ packages:
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -6015,6 +6053,12 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
+
+  web-vitals@6.0.0:
+    resolution: {integrity: sha512-Guaibvy/+uNtL6Bsu4jmMJGzuSl91oeRH5iO9pPRbYftnFUr3yqT1TUNX/OE4o9HexuEMU3Kb/Wg7iKhlffZUA==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -7075,6 +7119,17 @@ snapshots:
   '@nolyfill/is-core-module@1.0.39': {}
 
   '@oxc-project/types@0.139.0': {}
+
+  '@posthog/browser-common@0.5.1':
+    dependencies:
+      '@posthog/core': 1.48.10
+      '@posthog/types': 1.405.3
+
+  '@posthog/core@1.48.10':
+    dependencies:
+      '@posthog/types': 1.405.3
+
+  '@posthog/types@1.405.3': {}
 
   '@prisma/adapter-pg@7.9.1':
     dependencies:
@@ -8488,6 +8543,9 @@ snapshots:
     dependencies:
       '@types/node': 18.19.130
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -9213,6 +9271,8 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  core-js@3.50.0: {}
+
   cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
@@ -9413,6 +9473,10 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dompurify@3.4.14:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dot-prop@6.0.1:
     dependencies:
@@ -9957,6 +10021,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.7):
     optionalDependencies:
       picomatch: 4.0.7
+
+  fflate@0.4.9: {}
 
   figures@6.1.0:
     dependencies:
@@ -11391,9 +11457,26 @@ snapshots:
 
   postgres@3.4.7: {}
 
+  posthog-js@1.418.16:
+    dependencies:
+      '@posthog/browser-common': 0.5.1
+      '@posthog/core': 1.48.10
+      '@posthog/types': 1.405.3
+      core-js: 3.50.0
+      dompurify: 3.4.14
+      fflate: 0.4.9
+      preact: 10.29.8
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+      web-vitals-soft-navs: web-vitals@6.0.0
+    transitivePeerDependencies:
+      - preact-render-to-string
+
   powershell-utils@0.1.0: {}
 
   powershell-utils@0.2.0: {}
+
+  preact@10.29.8: {}
 
   prelude-ls@1.2.1: {}
 
@@ -11477,6 +11560,8 @@ snapshots:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1
+
+  query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -12498,6 +12583,10 @@ snapshots:
       '@types/node': 26.2.0
     transitivePeerDependencies:
       - msw
+
+  web-vitals@5.3.0: {}
+
+  web-vitals@6.0.0: {}
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
@@ -18,6 +18,7 @@ import { publicEnv } from '@/lib/env';
 import { InAppSubscribeForm } from '@/components/billing/in-app-subscribe-form';
 import { yearlyDiscountPercent } from '@/lib/billing/pricing';
 import { markWelcomeTutorialPending } from '@/lib/welcome-tutorial';
+import { AnalyticsEvents, captureEvent } from '@/lib/analytics';
 
 const BASE_STEPS = [
   { id: 'workspace', label: 'Workspace', icon: Sparkles },
@@ -26,6 +27,8 @@ const BASE_STEPS = [
 ] as const;
 
 type StepId = (typeof BASE_STEPS)[number]['id'];
+type PlanOutcome = 'subscribed' | 'skipped' | 'already_entitled' | 'billing_disabled';
+type ProjectOutcome = 'created' | 'skipped';
 
 export default function OnboardingPage() {
   const router = useRouter();
@@ -34,6 +37,7 @@ export default function OnboardingPage() {
   const workspace = workspaces.find((w) => w.id === currentWorkspaceId) ?? workspaces[0] ?? null;
   const wsId = workspace?.id ?? '';
   const billingOn = publicEnv.billingEnabled;
+  const startedRef = useRef(false);
 
   const steps = billingOn
     ? BASE_STEPS
@@ -42,6 +46,9 @@ export default function OnboardingPage() {
   const [step, setStep] = useState<StepId>('workspace');
   const [done, setDone] = useState<Partial<Record<StepId, boolean>>>({});
   const [planSkipped, setPlanSkipped] = useState(false);
+  const [planOutcome, setPlanOutcome] = useState<PlanOutcome | null>(
+    billingOn ? null : 'billing_disabled',
+  );
 
   const { data: billing } = useQuery({
     queryKey: ['billing', wsId],
@@ -53,17 +60,43 @@ export default function OnboardingPage() {
 
   const stepIndex = steps.findIndex((s) => s.id === step);
 
+  useEffect(() => {
+    if (!user || startedRef.current) return;
+    startedRef.current = true;
+    captureEvent(AnalyticsEvents.onboardingStarted, {
+      billing_enabled: billingOn,
+      workspace_id: wsId || undefined,
+    });
+  }, [user, billingOn, wsId]);
+
   const finishMut = useMutation({
-    mutationFn: completeOnboarding,
-    onSuccess: async (_data, destination: string | void) => {
+    mutationFn: async (_vars: {
+      destination?: string;
+      projectOutcome: ProjectOutcome;
+    }) => completeOnboarding(),
+    onSuccess: async (_data, vars) => {
+      captureEvent(AnalyticsEvents.onboardingCompleted, {
+        plan_outcome: planOutcome ?? (billingOn ? 'skipped' : 'billing_disabled'),
+        project_outcome: vars.projectOutcome,
+        destination: vars.destination ?? '/dashboard',
+      });
       markWelcomeTutorialPending();
       await qc.invalidateQueries({ queryKey: ['auth', 'me'] });
-      router.replace(typeof destination === 'string' && destination ? destination : '/dashboard');
+      router.replace(vars.destination || '/dashboard');
     },
     onError: (e) => toast.error(e instanceof Error ? e.message : 'Something went wrong'),
   });
 
-  const finish = (destination?: string) => finishMut.mutate(destination);
+  const finish = (opts?: { destination?: string; projectOutcome?: ProjectOutcome }) => {
+    const projectOutcome = opts?.projectOutcome ?? 'skipped';
+    if (projectOutcome === 'skipped') {
+      captureEvent(AnalyticsEvents.onboardingProjectContinued, { outcome: 'skipped' });
+    }
+    finishMut.mutate({
+      destination: opts?.destination,
+      projectOutcome,
+    });
+  };
 
   if (!user || !workspace) {
     return (
@@ -137,8 +170,19 @@ export default function OnboardingPage() {
               workspaceId={wsId}
               initialName={workspace.name}
               onDone={() => {
+                captureEvent(AnalyticsEvents.onboardingWorkspaceCompleted, {
+                  workspace_id: wsId,
+                });
                 setDone((d) => ({ ...d, workspace: true }));
-                setStep(billingOn ? 'plan' : 'project');
+                if (billingOn) {
+                  setStep('plan');
+                } else {
+                  setPlanOutcome('billing_disabled');
+                  captureEvent(AnalyticsEvents.onboardingPlanContinued, {
+                    outcome: 'billing_disabled',
+                  });
+                  setStep('project');
+                }
               }}
             />
           )}
@@ -147,14 +191,27 @@ export default function OnboardingPage() {
               workspaceId={wsId}
               entitled={entitled}
               onSubscribed={() => {
+                setPlanOutcome('subscribed');
+                captureEvent(AnalyticsEvents.onboardingPlanContinued, { outcome: 'subscribed' });
+                setDone((d) => ({ ...d, plan: true }));
+                setPlanSkipped(false);
+                setStep('project');
+              }}
+              onAlreadyEntitled={() => {
+                setPlanOutcome('already_entitled');
+                captureEvent(AnalyticsEvents.onboardingPlanContinued, {
+                  outcome: 'already_entitled',
+                });
                 setDone((d) => ({ ...d, plan: true }));
                 setPlanSkipped(false);
                 setStep('project');
               }}
               onSkip={() => {
+                setPlanOutcome('skipped');
+                captureEvent(AnalyticsEvents.onboardingPlanContinued, { outcome: 'skipped' });
                 setPlanSkipped(true);
                 setDone((d) => ({ ...d, plan: true }));
-                finish();
+                finish({ projectOutcome: 'skipped' });
               }}
             />
           )}
@@ -163,10 +220,14 @@ export default function OnboardingPage() {
               workspaceId={wsId}
               finishing={finishMut.isPending}
               onDone={(projectId) => {
+                captureEvent(AnalyticsEvents.onboardingProjectContinued, {
+                  outcome: 'created',
+                  project_id: projectId,
+                });
                 setDone((d) => ({ ...d, project: true }));
-                finish(`/projects/${projectId}`);
+                finish({ destination: `/projects/${projectId}`, projectOutcome: 'created' });
               }}
-              onSkip={() => finish()}
+              onSkip={() => finish({ projectOutcome: 'skipped' })}
             />
           )}
         </div>
@@ -235,11 +296,13 @@ function PlanStep({
   workspaceId,
   entitled,
   onSubscribed,
+  onAlreadyEntitled,
   onSkip,
 }: {
   workspaceId: string;
   entitled: boolean;
   onSubscribed: () => void;
+  onAlreadyEntitled: () => void;
   onSkip: () => void;
 }) {
   const discount = yearlyDiscountPercent();
@@ -251,7 +314,7 @@ function PlanStep({
           title="You're on Peon Pro"
           description="Your workspace already has an active subscription. Continue to create a project."
         />
-        <Button onClick={onSubscribed}>
+        <Button onClick={onAlreadyEntitled}>
           Continue <ArrowRight className="size-4" />
         </Button>
       </div>

--- a/src/components/app/app-sidebar.tsx
+++ b/src/components/app/app-sidebar.tsx
@@ -49,6 +49,7 @@ import { useAuthStore } from '@/store/auth';
 import { logout } from '@/services/api/auth';
 import { sectionsForService } from '@/lib/service-sections';
 import { useServiceDetail } from '@/lib/queries/service';
+import { resetAnalytics } from '@/lib/analytics';
 import { cn } from '@/lib/utils';
 
 interface NavItem {
@@ -189,6 +190,7 @@ export function AppSidebar() {
       await logout();
     } finally {
       clear();
+      resetAnalytics();
       qc.removeQueries({ queryKey: ['auth', 'me'] });
       toast.success('Signed out');
       router.replace('/login');

--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('posthog-js', () => ({
+  default: {
+    capture: vi.fn(),
+    identify: vi.fn(),
+    reset: vi.fn(),
+  },
+}));
+
+import posthog from 'posthog-js';
+import {
+  AnalyticsEvents,
+  captureEvent,
+  identifyUser,
+  resetAnalytics,
+} from '@/lib/analytics';
+
+describe('analytics helpers', () => {
+  beforeEach(() => {
+    vi.stubGlobal('window', {});
+    process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN = 'phc_test';
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+    vi.unstubAllGlobals();
+  });
+
+  it('captures named onboarding events when enabled', () => {
+    captureEvent(AnalyticsEvents.onboardingStarted, { billing_enabled: true });
+    expect(posthog.capture).toHaveBeenCalledWith('onboarding_started', {
+      billing_enabled: true,
+    });
+  });
+
+  it('identifies and resets users', () => {
+    identifyUser({
+      id: 'u1',
+      email: 'a@b.co',
+      name: 'Ada',
+      isOnboarded: false,
+    });
+    expect(posthog.identify).toHaveBeenCalledWith('u1', {
+      email: 'a@b.co',
+      name: 'Ada',
+      is_onboarded: false,
+    });
+    resetAnalytics();
+    expect(posthog.reset).toHaveBeenCalled();
+  });
+
+  it('no-ops without a project token', () => {
+    delete process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+    captureEvent(AnalyticsEvents.onboardingCompleted);
+    expect(posthog.capture).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,39 @@
+import posthog from 'posthog-js';
+
+/** True when the browser PostHog SDK was initialized (token present). */
+export function isPosthogEnabled(): boolean {
+  return !!process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN?.trim();
+}
+
+export function captureEvent(
+  event: string,
+  properties?: Record<string, string | number | boolean | null | undefined>,
+): void {
+  if (typeof window === 'undefined' || !isPosthogEnabled()) return;
+  posthog.capture(event, properties);
+}
+
+export function identifyUser(
+  user: { id: string; email: string; name: string | null; isOnboarded: boolean },
+): void {
+  if (typeof window === 'undefined' || !isPosthogEnabled()) return;
+  posthog.identify(user.id, {
+    email: user.email,
+    name: user.name ?? undefined,
+    is_onboarded: user.isOnboarded,
+  });
+}
+
+export function resetAnalytics(): void {
+  if (typeof window === 'undefined' || !isPosthogEnabled()) return;
+  posthog.reset();
+}
+
+/** Onboarding funnel + step events. Keep names stable for PostHog insights. */
+export const AnalyticsEvents = {
+  onboardingStarted: 'onboarding_started',
+  onboardingWorkspaceCompleted: 'onboarding_workspace_completed',
+  onboardingPlanContinued: 'onboarding_plan_continued',
+  onboardingProjectContinued: 'onboarding_project_continued',
+  onboardingCompleted: 'onboarding_completed',
+} as const;

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -129,6 +129,9 @@ export const publicEnv = {
   stripePublishableKey: process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? '',
   /** Mirrors server `isBillingEnabled` for UI (publishable key present). */
   billingEnabled: !!(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? '').trim(),
+  /** PostHog project token (browser). Empty disables analytics. */
+  posthogToken: process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN ?? '',
+  posthogHost: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://us.i.posthog.com',
 };
 
 /** Absolute URL into the marketing site (peon.sh). */

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -7,6 +7,7 @@ import { getMe, logout } from '@/services/api/auth';
 import { useAuthStore } from '@/store/auth';
 import { isPublicPath } from '@/lib/routes/config';
 import { postAuthPath } from '@/lib/auth/post-auth-path';
+import { identifyUser, resetAnalytics } from '@/lib/analytics';
 
 /**
  * Hydrates the auth store from `/api/auth/me`. Middleware already enforces
@@ -39,7 +40,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const settledError = isError && isFetched && !isFetching && fetchStatus === 'idle';
 
   useEffect(() => {
-    if (data) setSession(data.user, data.workspaces);
+    if (data) {
+      setSession(data.user, data.workspaces);
+      identifyUser(data.user);
+    }
   }, [data, setSession]);
 
   // Route new users through the onboarding wizard until they finish or skip it.
@@ -74,6 +78,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       if (guestClearedRef.current) return;
       guestClearedRef.current = true;
       clear();
+      resetAnalytics();
       void logout().catch(() => undefined);
       return;
     }
@@ -81,6 +86,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     if (publicRoute || clearingRef.current) return;
     clearingRef.current = true;
     clear();
+    resetAnalytics();
     qc.removeQueries({ queryKey: ['auth', 'me'] });
     void logout()
       .catch(() => undefined)


### PR DESCRIPTION
## Summary
- Install PostHog (`posthog-js` + `instrumentation-client.ts`) behind `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN` / `NEXT_PUBLIC_POSTHOG_HOST`.
- Identify users (id + email) after login and reset on logout so session replays can be found by email.
- Capture onboarding funnel events: started → workspace → plan → project → completed.
- PostHog funnel + dashboard already created in Advant project ([funnel](https://us.posthog.com/project/215505/insights/Fudev2zw), [dashboard](https://us.posthog.com/project/215505/dashboard/2030168)).

## Test plan
- [ ] Set `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN` in `.env` and restart `pnpm dev`
- [ ] Complete onboarding and confirm events appear in PostHog Live events
- [ ] Confirm person has `email` set and session recording is linked
- [ ] Confirm logout resets identity (new anonymous session)
- [ ] `pnpm exec vitest run src/lib/__tests__/analytics.test.ts`


Made with [Cursor](https://cursor.com)