### PR TITLE
Route PostHog through Advant reverse proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,9 +83,11 @@ GITHUB_APP_CLIENT_ID=
 GITHUB_APP_CLIENT_SECRET=
 SENTRY_DSN=
 
-# PostHog product analytics (leave empty to disable)
+# PostHog product analytics (leave token empty to disable)
 NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=
-NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+# Managed reverse proxy (ingestion). UI host keeps toolbar/recording links on PostHog.
+NEXT_PUBLIC_POSTHOG_HOST=https://t.advant.xyz
+NEXT_PUBLIC_POSTHOG_UI_HOST=https://us.posthog.com
 
 # --- Workspace agent chat ---
 # Configure LLM API keys per workspace in Settings → LLMs.

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -4,7 +4,10 @@ const token = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN?.trim();
 
 if (token) {
   posthog.init(token, {
-    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
+    // Managed reverse proxy (avoids ad blockers); override with NEXT_PUBLIC_POSTHOG_HOST.
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://t.advant.xyz',
+    // Required when using a proxy so toolbar / recording links open PostHog UI.
+    ui_host: process.env.NEXT_PUBLIC_POSTHOG_UI_HOST || 'https://us.posthog.com',
     defaults: '2026-05-30',
     person_profiles: 'identified_only',
   });

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -131,7 +131,10 @@ export const publicEnv = {
   billingEnabled: !!(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? '').trim(),
   /** PostHog project token (browser). Empty disables analytics. */
   posthogToken: process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN ?? '',
-  posthogHost: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://us.i.posthog.com',
+  /** Ingestion host — prefer managed reverse proxy. */
+  posthogHost: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://t.advant.xyz',
+  /** PostHog app UI (links/toolbar) when api_host is a proxy. */
+  posthogUiHost: process.env.NEXT_PUBLIC_POSTHOG_UI_HOST ?? 'https://us.posthog.com',
 };
 
 /** Absolute URL into the marketing site (peon.sh). */


### PR DESCRIPTION
## Summary
- Point PostHog `api_host` at the managed reverse proxy `https://t.advant.xyz` (fewer ad-blocker drops).
- Set `ui_host` to `https://us.posthog.com` so toolbar / recording links still open PostHog.
- Document `NEXT_PUBLIC_POSTHOG_HOST` and `NEXT_PUBLIC_POSTHOG_UI_HOST` in `.env.example`.

## Test plan
- [ ] Ensure local/prod `.env` has `NEXT_PUBLIC_POSTHOG_HOST=https://t.advant.xyz` (or rely on the new default)
- [ ] Restart app and confirm Live events still arrive in PostHog
- [ ] Confirm Network requests go to `t.advant.xyz` (not `us.i.posthog.com`)
- [ ] Open a session recording / person link and confirm it lands on `us.posthog.com`


Made with [Cursor](https://cursor.com)