### PR TITLE
fix: preserve scheduled task error output

### DIFF
--- a/src/services/internal/task/__tests__/engine.test.ts
+++ b/src/services/internal/task/__tests__/engine.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    scheduledTask: { findUnique: vi.fn() },
+    scheduledTaskExecution: { update: vi.fn() },
+  },
+}));
+
+vi.mock('@/lib/ssh', () => ({
+  sshPool: { exec: vi.fn() },
+  sshTargetForServer: vi.fn(),
+}));
+
+vi.mock('@/services/internal/notifications/events', () => ({
+  notifyService: vi.fn(),
+}));
+
+import { prisma } from '@/lib/prisma';
+import { sshPool, sshTargetForServer } from '@/lib/ssh';
+import { notifyService } from '@/services/internal/notifications/events';
+import { runScheduledTask } from '@/services/internal/task/engine';
+
+const taskFindUnique = vi.mocked(prisma.scheduledTask.findUnique);
+const executionUpdate = vi.mocked(prisma.scheduledTaskExecution.update);
+const exec = vi.mocked(sshPool.exec);
+const targetForServer = vi.mocked(sshTargetForServer);
+const notify = vi.mocked(notifyService);
+
+describe('runScheduledTask', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    taskFindUnique.mockResolvedValue({
+      id: 'task1',
+      name: 'backup',
+      command: 'npm run backup',
+      container: null,
+      service: {
+        id: 'svc1',
+        name: 'app',
+        uuid: 'uuid-1',
+        serverId: 'srv1',
+        activeContainerName: 'app-1',
+      },
+    } as never);
+    targetForServer.mockResolvedValue({ host: 'host', user: 'user' } as never);
+    executionUpdate.mockResolvedValue({} as never);
+    notify.mockResolvedValue(undefined);
+  });
+
+  it('keeps command output when a task exits with an error', async () => {
+    exec.mockResolvedValue({
+      code: 1,
+      stdout: 'backup started\n',
+      stderr: 'permission denied\n',
+    } as never);
+
+    await expect(runScheduledTask('task1', 'execution1')).rejects.toThrow(
+      'backup started\npermission denied\n',
+    );
+
+    expect(executionUpdate).toHaveBeenLastCalledWith({
+      where: { id: 'execution1' },
+      data: expect.objectContaining({
+        status: 'FAILED',
+        message: 'backup started\npermission denied\n',
+      }),
+    });
+    expect(notify).toHaveBeenCalledWith(
+      'svc1',
+      'task_failure',
+      expect.objectContaining({
+        text: expect.stringContaining('permission denied'),
+      }),
+    );
+  });
+});

--- a/src/services/internal/task/engine.ts
+++ b/src/services/internal/task/engine.ts
@@ -30,7 +30,9 @@ export async function runScheduledTask(taskId: string, executionId: string): Pro
         finishedAt: new Date(),
       },
     });
-    if (res.code !== 0) throw new Error('Task exited non-zero.');
+    if (res.code !== 0) {
+      throw new Error((res.stdout + res.stderr).slice(0, 10000) || 'Task exited non-zero.');
+    }
     await notifyService(svc.id, 'task_success', {
       subject: `Scheduled task succeeded: ${task.name}`,
       text: `Scheduled task "${task.name}" on "${svc.name}" completed successfully.`,


### PR DESCRIPTION
Fixes #80

When a scheduled task exited with a non-zero status, the command output was written to the execution record and then replaced with `Task exited non-zero.` in the error handler.

Keep the captured output in the error so it remains available in the execution record and failure notification. The generic message is still used when the command produced no output.

Tests:
- `pnpm test:unit`
