### PR TITLE
fix: invalidate disconnected ssh connections

### DIFF
--- a/src/lib/ssh/__tests__/pool-race.test.ts
+++ b/src/lib/ssh/__tests__/pool-race.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  connect: null as (() => void) | null,
+  dispose: vi.fn(),
+}));
+
+vi.mock('node-ssh', () => ({
+  NodeSSH: class {
+    connect = vi.fn(() => new Promise<void>((resolve) => {
+      state.connect = resolve;
+    }));
+    dispose = state.dispose;
+    isConnected = vi.fn(() => true);
+    execCommand = vi.fn();
+    connection = null;
+  },
+}));
+
+vi.mock('@/lib/e2e', () => ({
+  isE2eMode: vi.fn(() => false),
+}));
+
+vi.mock('../host', () => ({
+  sshConnectHostOptions: vi.fn(() => ({ host: 'host' })),
+}));
+
+vi.mock('../host-key', () => ({
+  createHostKeyVerifier: vi.fn(() => ({ verify: vi.fn(), mismatch: null, learned: null })),
+  HostKeyMismatchError: class HostKeyMismatchError extends Error {},
+}));
+
+import { sshPool } from '../pool';
+import type { SshTarget } from '../types';
+
+const target: SshTarget = {
+  id: 'srv-race',
+  host: '127.0.0.1',
+  port: 22,
+  username: 'root',
+  privateKey: 'key',
+};
+
+describe('sshPool connection invalidation', () => {
+  beforeEach(() => {
+    sshPool.disconnect(target.id);
+    state.connect = null;
+    state.dispose.mockClear();
+  });
+
+  it('does not reinsert a connection after disconnect during connect', async () => {
+    const pending = sshPool.exec(target, 'echo ok');
+    await Promise.resolve();
+
+    sshPool.disconnect(target.id);
+    state.connect?.();
+
+    await expect(pending).rejects.toThrow('disconnected while connecting');
+    expect(state.dispose).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lib/ssh/pool.ts
+++ b/src/lib/ssh/pool.ts
@@ -9,6 +9,7 @@ interface PooledConnection {
   lastUsed: number;
   connecting: Promise<NodeSSH> | null;
   serverId: string;
+  generation: symbol;
 }
 
 /** Stable identity for a target so IP/user/key changes drop stale pooled sessions. */
@@ -104,18 +105,37 @@ class SshPool {
     this.disconnect(target.id);
 
     const connecting = this.connect(target, key);
+    const generation = Symbol('ssh-connection');
     this.connections.set(key, {
       ssh: null as unknown as NodeSSH,
       lastUsed: Date.now(),
       connecting,
       serverId: target.id,
+      generation,
     });
     try {
       const ssh = await connecting;
-      this.connections.set(key, { ssh, lastUsed: Date.now(), connecting: null, serverId: target.id });
+      const current = this.connections.get(key);
+      if (!current || current.generation !== generation) {
+        try {
+          ssh.dispose();
+        } catch {
+          // The connection was invalidated while it was opening.
+        }
+        throw new Error('SSH connection was disconnected while connecting.');
+      }
+      this.connections.set(key, {
+        ssh,
+        lastUsed: Date.now(),
+        connecting: null,
+        serverId: target.id,
+        generation,
+      });
       return ssh;
     } catch (err) {
-      this.connections.delete(key);
+      if (this.connections.get(key)?.generation === generation) {
+        this.connections.delete(key);
+      }
       throw err;
     }
   }


### PR DESCRIPTION
Fixes #86

When `disconnect()` ran while an SSH connection was still being established, the connection was added back to the pool after the connect promise resolved. This could restore a session that had already been invalidated after server connection details changed.

Track each connection attempt with a generation token. A connection that no longer matches the current pool entry is disposed and the waiting operation receives an error instead of reinserting it.

Tests:
- `pnpm test:unit`
